### PR TITLE
Invalidate cache for the slogan block

### DIFF
--- a/web/themes/custom/move_mil/preprocess/block/block__system_branding_block.preprocess.inc
+++ b/web/themes/custom/move_mil/preprocess/block/block__system_branding_block.preprocess.inc
@@ -16,4 +16,7 @@ function move_mil_preprocess_block__system_branding_block(&$variables) {
   if ($node instanceof \Drupal\node\NodeInterface) {
     $variables['nid'] = $node->id();
   }
+  $variables['#cache']['max-age'] = 0;
 }
+
+

--- a/web/themes/custom/move_mil/preprocess/block/block__system_branding_block.preprocess.inc
+++ b/web/themes/custom/move_mil/preprocess/block/block__system_branding_block.preprocess.inc
@@ -18,5 +18,3 @@ function move_mil_preprocess_block__system_branding_block(&$variables) {
   }
   $variables['#cache']['max-age'] = 0;
 }
-
-


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- Allow the slogan to change between SME and the rest of the site
- Invalidates the system branding block cache, so the preprocess and twing template are executed again every time a node is loaded, this way the slogan can change.
- The block cache only contains the slogan so it's not heavy to load every time.

## Testing

To verify the changes proposed in this pull request…

1. Pull change and clear cache.
1. Go to /sme and verify the slogan is Official DOD PPSO & TSP Moving Portal
1. Go to other page and verify the slogan is Official DOD Customer Moving Portal
