### PR TITLE
Config with structure for dynamic SME page

### DIFF
--- a/config/sync/block.block.sme_advisories.yml
+++ b/config/sync/block.block.sme_advisories.yml
@@ -1,0 +1,30 @@
+uuid: 12610e14-f160-401c-815b-053b0404c0f1
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.sme_section
+  module:
+    - system
+    - views
+  theme:
+    - move_mil
+id: sme_advisories
+theme: move_mil
+region: content
+weight: -3
+provider: null
+plugin: 'views_block:sme_section-block_1'
+settings:
+  id: 'views_block:sme_section-block_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/block.block.sme_direct_procurement_method.yml
+++ b/config/sync/block.block.sme_direct_procurement_method.yml
@@ -1,0 +1,30 @@
+uuid: c465b50f-d905-4d3b-bab3-a96c44efe0d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.sme_section
+  module:
+    - system
+    - views
+  theme:
+    - move_mil
+id: sme_direct_procurement_method
+theme: move_mil
+region: content
+weight: -2
+provider: null
+plugin: 'views_block:sme_section-block_2'
+settings:
+  id: 'views_block:sme_section-block_2'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/block.block.sme_household_goods.yml
+++ b/config/sync/block.block.sme_household_goods.yml
@@ -1,0 +1,30 @@
+uuid: 620699ed-3e30-4efa-be10-d13af4aeba75
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.sme_section
+  module:
+    - system
+    - views
+  theme:
+    - move_mil
+id: sme_household_goods
+theme: move_mil
+region: content
+weight: -1
+provider: null
+plugin: 'views_block:sme_section-block_3'
+settings:
+  id: 'views_block:sme_section-block_3'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/block.block.sme_non_temporary_storage.yml
+++ b/config/sync/block.block.sme_non_temporary_storage.yml
@@ -1,0 +1,30 @@
+uuid: fc3f997b-fffb-43e8-b765-c51368c4954f
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.sme_section
+  module:
+    - system
+    - views
+  theme:
+    - move_mil
+id: sme_non_temporary_storage
+theme: move_mil
+region: content
+weight: 0
+provider: null
+plugin: 'views_block:sme_section-block_4'
+settings:
+  id: 'views_block:sme_section-block_4'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/block.block.sme_non_temporary_storage_retrograde_program.yml
+++ b/config/sync/block.block.sme_non_temporary_storage_retrograde_program.yml
@@ -1,0 +1,30 @@
+uuid: 0786ad28-cd80-4f11-a59b-d8757b60d746
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.sme_section
+  module:
+    - system
+    - views
+  theme:
+    - move_mil
+id: sme_non_temporary_storage_retrograde_program
+theme: move_mil
+region: content
+weight: 1
+provider: null
+plugin: 'views_block:sme_section-block_5'
+settings:
+  id: 'views_block:sme_section-block_5'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/block.block.sme_online_education_series.yml
+++ b/config/sync/block.block.sme_online_education_series.yml
@@ -1,0 +1,30 @@
+uuid: 4669b828-09ae-4a3d-b03a-45e79bcdcb68
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.sme_section
+  module:
+    - system
+    - views
+  theme:
+    - move_mil
+id: sme_online_education_series
+theme: move_mil
+region: content
+weight: 2
+provider: null
+plugin: 'views_block:sme_section-block_6'
+settings:
+  id: 'views_block:sme_section-block_6'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/block.block.sme_personal_property.yml
+++ b/config/sync/block.block.sme_personal_property.yml
@@ -1,0 +1,30 @@
+uuid: e9c74a6e-29bf-473e-bc8d-8736f0f5327a
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.sme_section
+  module:
+    - system
+    - views
+  theme:
+    - move_mil
+id: sme_personal_property
+theme: move_mil
+region: content
+weight: -4
+provider: null
+plugin: 'views_block:sme_section-block_8'
+settings:
+  id: 'views_block:sme_section-block_8'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/block.block.sme_privately_owned_vehicles.yml
+++ b/config/sync/block.block.sme_privately_owned_vehicles.yml
@@ -1,0 +1,30 @@
+uuid: 7a878470-63f1-40eb-b7b2-326447e53335
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.sme_section
+  module:
+    - system
+    - views
+  theme:
+    - move_mil
+id: sme_privately_owned_vehicles
+theme: move_mil
+region: content
+weight: 3
+provider: null
+plugin: 'views_block:sme_section-block_7'
+settings:
+  id: 'views_block:sme_section-block_7'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/block.block.smesections.yml
+++ b/config/sync/block.block.smesections.yml
@@ -1,0 +1,29 @@
+uuid: 10ab9d81-3ddb-45b3-87c4-4020c36c950d
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.sme-sections
+  module:
+    - system
+  theme:
+    - move_mil
+id: smesections
+theme: move_mil
+region: sidebar_first
+weight: 0
+provider: null
+plugin: 'system_menu_block:sme-sections'
+settings:
+  id: 'system_menu_block:sme-sections'
+  label: 'SME Sections'
+  provider: system
+  label_display: visible
+  level: 1
+  depth: 0
+visibility:
+  request_path:
+    id: request_path
+    pages: /sme-page
+    negate: false
+    context_mapping: {  }

--- a/config/sync/core.base_field_override.node.sme_document.title.yml
+++ b/config/sync/core.base_field_override.node.sme_document.title.yml
@@ -1,0 +1,18 @@
+uuid: 993dbe75-b949-4a50-84e1-2294bd3995bd
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sme_document
+id: node.sme_document.title
+field_name: title
+entity_type: node
+bundle: sme_document
+label: 'Document Title'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.entity_form_display.node.sme_document.default.yml
+++ b/config/sync/core.entity_form_display.node.sme_document.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.sme_document.field_document_file
     - field.field.node.sme_document.field_document_id
     - field.field.node.sme_document.field_document_updated_date
+    - field.field.node.sme_document.field_sme_section
     - node.type.sme_document
   module:
     - datetime
@@ -48,6 +49,12 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
+    region: content
+  field_sme_section:
+    weight: 126
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
     region: content
   node_class:
     type: string_textfield

--- a/config/sync/core.entity_form_display.node.sme_document.default.yml
+++ b/config/sync/core.entity_form_display.node.sme_document.default.yml
@@ -1,0 +1,104 @@
+uuid: 81037c30-e8c5-4640-a3ab-c01d6e6239e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.sme_document.field_document_archive_date
+    - field.field.node.sme_document.field_document_file
+    - field.field.node.sme_document.field_document_id
+    - field.field.node.sme_document.field_document_updated_date
+    - node.type.sme_document
+  module:
+    - datetime
+    - file
+    - path
+id: node.sme_document.default
+targetEntityType: node
+bundle: sme_document
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_document_archive_date:
+    weight: 124
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_document_file:
+    weight: 125
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
+  field_document_id:
+    weight: 122
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+    region: content
+  field_document_updated_date:
+    weight: 123
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  node_class:
+    type: string_textfield
+    weight: 35
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/config/sync/core.entity_view_display.node.sme_document.default.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.default.yml
@@ -1,0 +1,60 @@
+uuid: b5070dd7-90be-4e8c-93d3-7a11773cb19d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.sme_document.field_document_archive_date
+    - field.field.node.sme_document.field_document_file
+    - field.field.node.sme_document.field_document_id
+    - field.field.node.sme_document.field_document_updated_date
+    - node.type.sme_document
+  module:
+    - datetime
+    - file
+    - user
+id: node.sme_document.default
+targetEntityType: node
+bundle: sme_document
+mode: default
+content:
+  field_document_archive_date:
+    weight: 104
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  field_document_file:
+    weight: 105
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    type: file_default
+    region: content
+  field_document_id:
+    weight: 102
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_integer
+    region: content
+  field_document_updated_date:
+    weight: 103
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/sync/core.entity_view_display.node.sme_document.default.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.sme_document.field_document_file
     - field.field.node.sme_document.field_document_id
     - field.field.node.sme_document.field_document_updated_date
+    - field.field.node.sme_document.field_sme_section
     - node.type.sme_document
   module:
     - datetime
@@ -18,25 +19,24 @@ bundle: sme_document
 mode: default
 content:
   field_document_archive_date:
-    weight: 104
+    type: datetime_default
+    weight: 4
+    region: content
     label: above
     settings:
       format_type: medium
       timezone_override: ''
     third_party_settings: {  }
-    type: datetime_default
-    region: content
   field_document_file:
-    weight: 105
+    weight: 3
     label: above
-    settings:
-      use_description_as_link_text: true
+    settings: {  }
     third_party_settings: {  }
-    type: file_default
+    type: file_url_plain
     region: content
   field_document_id:
-    weight: 102
-    label: above
+    weight: 1
+    label: inline
     settings:
       thousand_separator: ''
       prefix_suffix: true
@@ -44,17 +44,25 @@ content:
     type: number_integer
     region: content
   field_document_updated_date:
-    weight: 103
-    label: above
+    weight: 2
+    label: inline
     settings:
-      format_type: medium
       timezone_override: ''
+      format_type: short
     third_party_settings: {  }
     type: datetime_default
     region: content
+  field_sme_section:
+    type: entity_reference_label
+    weight: 5
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
   links:
-    weight: 100
+    weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/config/sync/core.entity_view_display.node.sme_document.teaser.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.teaser.yml
@@ -1,0 +1,28 @@
+uuid: 78fc5763-8f22-4906-a820-a520b32e04fb
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.sme_document.field_document_archive_date
+    - field.field.node.sme_document.field_document_file
+    - field.field.node.sme_document.field_document_id
+    - field.field.node.sme_document.field_document_updated_date
+    - node.type.sme_document
+  module:
+    - user
+id: node.sme_document.teaser
+targetEntityType: node
+bundle: sme_document
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_document_archive_date: true
+  field_document_file: true
+  field_document_id: true
+  field_document_updated_date: true

--- a/config/sync/core.entity_view_display.node.sme_document.teaser.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.teaser.yml
@@ -8,21 +8,43 @@ dependencies:
     - field.field.node.sme_document.field_document_file
     - field.field.node.sme_document.field_document_id
     - field.field.node.sme_document.field_document_updated_date
+    - field.field.node.sme_document.field_sme_section
     - node.type.sme_document
   module:
+    - datetime
+    - file
     - user
 id: node.sme_document.teaser
 targetEntityType: node
 bundle: sme_document
 mode: teaser
 content:
-  links:
-    weight: 100
+  field_document_file:
+    type: file_url_plain
+    weight: 2
+    region: content
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+  field_document_id:
+    type: number_integer
+    weight: 0
     region: content
+    label: inline
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+  field_document_updated_date:
+    type: datetime_default
+    weight: 1
+    region: content
+    label: inline
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
 hidden:
   field_document_archive_date: true
-  field_document_file: true
-  field_document_id: true
-  field_document_updated_date: true
+  field_sme_section: true
+  links: true

--- a/config/sync/core.entity_view_display.node.sme_document.teaser.yml
+++ b/config/sync/core.entity_view_display.node.sme_document.teaser.yml
@@ -20,11 +20,12 @@ bundle: sme_document
 mode: teaser
 content:
   field_document_file:
-    type: file_url_plain
+    type: file_default
     weight: 2
     region: content
     label: hidden
-    settings: {  }
+    settings:
+      use_description_as_link_text: true
     third_party_settings: {  }
   field_document_id:
     type: number_integer

--- a/config/sync/field.field.node.sme_document.field_document_archive_date.yml
+++ b/config/sync/field.field.node.sme_document.field_document_archive_date.yml
@@ -1,0 +1,21 @@
+uuid: 63349cc1-7d0a-4ccb-8e3c-4bf3c0444b61
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_document_archive_date
+    - node.type.sme_document
+  module:
+    - datetime
+id: node.sme_document.field_document_archive_date
+field_name: field_document_archive_date
+entity_type: node
+bundle: sme_document
+label: 'Document Expiration/Archive Date'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.node.sme_document.field_document_file.yml
+++ b/config/sync/field.field.node.sme_document.field_document_file.yml
@@ -1,0 +1,27 @@
+uuid: 421b2d09-7970-4685-80b3-5568ca1f8c42
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_document_file
+    - node.type.sme_document
+  module:
+    - file
+id: node.sme_document.field_document_file
+field_name: field_document_file
+entity_type: node
+bundle: sme_document
+label: 'Document File'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'doc docx pdf ppt'
+  max_filesize: ''
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/config/sync/field.field.node.sme_document.field_document_id.yml
+++ b/config/sync/field.field.node.sme_document.field_document_id.yml
@@ -1,0 +1,23 @@
+uuid: b728c1f6-93d7-4b7d-a4f1-5ca0539a1747
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_document_id
+    - node.type.sme_document
+id: node.sme_document.field_document_id
+field_name: field_document_id
+entity_type: node
+bundle: sme_document
+label: 'Document ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/sync/field.field.node.sme_document.field_document_updated_date.yml
+++ b/config/sync/field.field.node.sme_document.field_document_updated_date.yml
@@ -1,0 +1,24 @@
+uuid: 5843dfb4-bd97-4d4c-ac93-67146da4ace7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_document_updated_date
+    - node.type.sme_document
+  module:
+    - datetime
+id: node.sme_document.field_document_updated_date
+field_name: field_document_updated_date
+entity_type: node
+bundle: sme_document
+label: 'Document Updated Date'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    default_date_type: now
+    default_date: now
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.node.sme_document.field_document_updated_date.yml
+++ b/config/sync/field.field.node.sme_document.field_document_updated_date.yml
@@ -11,7 +11,7 @@ id: node.sme_document.field_document_updated_date
 field_name: field_document_updated_date
 entity_type: node
 bundle: sme_document
-label: 'Document Updated Date'
+label: 'Last Updated'
 description: ''
 required: false
 translatable: false

--- a/config/sync/field.field.node.sme_document.field_sme_section.yml
+++ b/config/sync/field.field.node.sme_document.field_sme_section.yml
@@ -1,0 +1,29 @@
+uuid: 5df0b2c1-abb9-4eb4-9d2b-86fc3de05d49
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sme_section
+    - node.type.sme_document
+    - taxonomy.vocabulary.sme_section
+id: node.sme_document.field_sme_section
+field_name: field_sme_section
+entity_type: node
+bundle: sme_document
+label: 'SME Section'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      sme_section: sme_section
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_document_archive_date.yml
+++ b/config/sync/field.storage.node.field_document_archive_date.yml
@@ -1,0 +1,20 @@
+uuid: c2079e2c-0ec1-479e-8f56-ee274e41f2a5
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_document_archive_date
+field_name: field_document_archive_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_document_file.yml
+++ b/config/sync/field.storage.node.field_document_file.yml
@@ -1,0 +1,23 @@
+uuid: 65881db8-f418-4308-ab44-523c01945961
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_document_file
+field_name: field_document_file
+entity_type: node
+type: file
+settings:
+  display_field: true
+  display_default: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_document_id.yml
+++ b/config/sync/field.storage.node.field_document_id.yml
@@ -1,0 +1,20 @@
+uuid: d026c9a1-b9fb-46ed-b22b-ad831eed356c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_document_id
+field_name: field_document_id
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_document_updated_date.yml
+++ b/config/sync/field.storage.node.field_document_updated_date.yml
@@ -1,0 +1,20 @@
+uuid: 662d7330-5ecf-4bdd-9ec2-2e8f3c9ef3f4
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_document_updated_date
+field_name: field_document_updated_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_sme_section.yml
+++ b/config/sync/field.storage.node.field_sme_section.yml
@@ -1,17 +1,17 @@
-uuid: 662d7330-5ecf-4bdd-9ec2-2e8f3c9ef3f4
+uuid: 647a954a-1b77-40ee-82e7-ba7b6e75bbd8
 langcode: en
 status: true
 dependencies:
   module:
-    - datetime
     - node
-id: node.field_document_updated_date
-field_name: field_document_updated_date
+    - taxonomy
+id: node.field_sme_section
+field_name: field_sme_section
 entity_type: node
-type: datetime
+type: entity_reference
 settings:
-  datetime_type: datetime
-module: datetime
+  target_type: taxonomy_term
+module: core
 locked: false
 cardinality: 1
 translatable: true

--- a/config/sync/node.type.sme_document.yml
+++ b/config/sync/node.type.sme_document.yml
@@ -1,0 +1,21 @@
+uuid: 7e964aca-d564-4eca-9528-3e1a3b8f2440
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - wysiwyg_template
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  wysiwyg_template:
+    default_template: ''
+name: 'SME Document'
+type: sme_document
+description: 'Document to be linked in SME section'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: true

--- a/config/sync/system.menu.sme-sections.yml
+++ b/config/sync/system.menu.sme-sections.yml
@@ -1,0 +1,8 @@
+uuid: e0ad8d36-c941-43e1-9693-14899c99711e
+langcode: en
+status: true
+dependencies: {  }
+id: sme-sections
+label: 'SME Sections'
+description: 'Used in the sidebar of the SME page to serve as jumplinks.'
+locked: false

--- a/config/sync/taxonomy.vocabulary.sme_section.yml
+++ b/config/sync/taxonomy.vocabulary.sme_section.yml
@@ -1,0 +1,9 @@
+uuid: 83d95d9c-15a7-448f-9b38-3c30bfd1f370
+langcode: en
+status: true
+dependencies: {  }
+name: 'SME Section'
+vid: sme_section
+description: 'Category of document for use on SME page'
+hierarchy: 0
+weight: 0

--- a/config/sync/views.view.sme_section.yml
+++ b/config/sync/views.view.sme_section.yml
@@ -147,50 +147,6 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
-        tid:
-          id: tid
-          table: taxonomy_index
-          field: tid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            - 15
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: sme_section
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
         field_document_archive_date_value:
           id: field_document_archive_date_value
           table: node__field_document_archive_date
@@ -265,7 +221,6 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -277,6 +232,958 @@ display:
     display_options:
       display_extenders: {  }
       display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_10:
+    display_plugin: block
+    id: block_10
+    display_title: 'SME Archive Section - Direct Procurement Method (DPM)'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Direct Procurement Method (DPM)'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 16
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_11:
+    display_plugin: block
+    id: block_11
+    display_title: 'SME Archive Section - Household Goods'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Household Goods'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            17: 17
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_12:
+    display_plugin: block
+    id: block_12
+    display_title: 'SME Archive Section - Non-Temporary Storage (NTS)'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Non-Temporary Storage (NTS)'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            18: 18
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_13:
+    display_plugin: block
+    id: block_13
+    display_title: 'SME Archive Section - Non-Temporary Storage (NTS) Retrograde Program'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Non-Temporary Storage (NTS) Retrograde Program'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            19: 19
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_14:
+    display_plugin: block
+    id: block_14
+    display_title: 'SME Archive Section - On-line Education Series'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'On-line Education Series'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            20: 20
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_15:
+    display_plugin: block
+    id: block_15
+    display_title: 'SME Archive Section - Privately Owned Vehicles (POVs)'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Privately Owned Vehicles (POVs)'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            21: 21
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_16:
+    display_plugin: block
+    id: block_16
+    display_title: 'SME Archive Section - Personal Property'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Personal Property'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+        sorts: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            22: 22
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      sorts:
+        field_document_updated_date_value:
+          id: field_document_updated_date_value
+          table: node__field_document_updated_date
+          field: field_document_updated_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
     cache_metadata:
       max-age: -1
       contexts:
@@ -1236,6 +2143,243 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_9:
+    display_plugin: block
+    id: block_9
+    display_title: 'SME Archive Section - Advisories'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 15
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: 'Archive Page'
+    position: 17
+    display_options:
+      display_extenders: {  }
+      path: sme/archive
+      title: 'SME Archive'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+        sorts: false
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '<'
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      sorts:
+        field_document_updated_date_value:
+          id: field_document_updated_date_value
+          table: node__field_document_updated_date
+          field: field_document_updated_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/config/sync/views.view.sme_section.yml
+++ b/config/sync/views.view.sme_section.yml
@@ -1,0 +1,1241 @@
+uuid: 5a5aaa17-c2e5-4830-a106-8dc987975053
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.sme_document
+    - taxonomy.vocabulary.sme_section
+  content:
+    - 'taxonomy_term:sme_section:0140036d-abea-43a0-98ee-34258ffe8e75'
+    - 'taxonomy_term:sme_section:91b9ee76-0b01-4e66-9425-97ef98e3a3e4'
+    - 'taxonomy_term:sme_section:9512d0e7-eaa5-4563-b028-0f40be0c8dd0'
+    - 'taxonomy_term:sme_section:a469942f-b9a1-4891-8646-663c311c1a9c'
+    - 'taxonomy_term:sme_section:ba54882a-052b-4804-b55f-0a435e2f57bb'
+    - 'taxonomy_term:sme_section:e4098639-50e2-4688-9f26-cb4b58133dd5'
+    - 'taxonomy_term:sme_section:f2954e9f-4bf8-4c08-9389-6078f70f3d65'
+    - 'taxonomy_term:sme_section:fbb91aa1-0fc0-4114-a6e3-b2f29607dcc8'
+  module:
+    - datetime
+    - node
+    - taxonomy
+    - user
+id: sme_section
+label: 'SME Sections'
+module: views
+description: 'Lists of SME documents, categorized by section'
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          items_per_page: 0
+          offset: 0
+      style:
+        type: html_list
+        options:
+          row_class: document-item
+          default_row_class: false
+          uses_fields: false
+          type: ul
+          wrapper_class: documents-section
+          class: document-list
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 15
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      sorts:
+        field_document_updated_date_value:
+          id: field_document_updated_date_value
+          table: node__field_document_updated_date
+          field: field_document_updated_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
+      title: Advisories
+      header: {  }
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          plugin_id: text
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: 'SME Section - Advisories'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_2:
+    display_plugin: block
+    id: block_2
+    display_title: 'SME Section - Direct Procurement Method (DPM)'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Direct Procurement Method (DPM)'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 16
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_3:
+    display_plugin: block
+    id: block_3
+    display_title: 'SME Section - Household Goods'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Household Goods'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            17: 17
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_4:
+    display_plugin: block
+    id: block_4
+    display_title: 'SME Section - Non-Temporary Storage (NTS)'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Non-Temporary Storage (NTS)'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            18: 18
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_5:
+    display_plugin: block
+    id: block_5
+    display_title: 'SME Section - Non-Temporary Storage (NTS) Retrograde Program'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Non-Temporary Storage (NTS) Retrograde Program'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            19: 19
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_6:
+    display_plugin: block
+    id: block_6
+    display_title: 'SME Section - On-line Education Series'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'On-line Education Series'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            20: 20
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_7:
+    display_plugin: block
+    id: block_7
+    display_title: 'SME Section - Privately Owned Vehicles (POVs)'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Privately Owned Vehicles (POVs)'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            21: 21
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_8:
+    display_plugin: block
+    id: block_8
+    display_title: 'SME Section - Personal Property'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Personal Property'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+        sorts: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sme_document: sme_document
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        tid:
+          id: tid
+          table: taxonomy_index
+          field: tid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            22: 22
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: sme_section
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_document_archive_date_value:
+          id: field_document_archive_date_value
+          table: node__field_document_archive_date
+          field: field_document_archive_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: today
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      sorts:
+        field_document_updated_date_value:
+          id: field_document_updated_date_value
+          table: node__field_document_updated_date
+          field: field_document_updated_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
+++ b/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
@@ -86,10 +86,13 @@
 
   <div class="document-link">
     <h3{{ title_attributes }}>
-      <a href="{{ content.field_document_file.0 }}" title="Download file">{{ label }}</a>
+      <a href="{{ file_url(content.field_document_file[0]['#file'].uri.value) }}" title="Download file">{{ label }}</a>
     </h3>
   </div>
 
   {{ content|without('field_document_file') }}
+  <div class="file-size">
+    <span class="field-label">File Size: </span><span class="field-value">{{ content.field_document_file[0]['#file'].filesize.value|number_format ~ ' bytes'|t }}</span>
+  </div>
 
 </article>

--- a/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
+++ b/web/themes/custom/move_mil/templates/system/view/node--sme-document--teaser.html.twig
@@ -1,0 +1,95 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+
+{{ attach_library('classy/node') }}
+<article{{ attributes.addClass(classes) }}>
+
+  <div class="document-link">
+    <h3{{ title_attributes }}>
+      <a href="{{ content.field_document_file.0 }}" title="Download file">{{ label }}</a>
+    </h3>
+  </div>
+
+  {{ content|without('field_document_file') }}
+
+</article>


### PR DESCRIPTION
This PR addresses Pivotal tickets [#161924549 - SME Document Content Type](https://www.pivotaltracker.com/story/show/161924549), [#161923738 - new SME page architecture](https://www.pivotaltracker.com/story/show/161923738), and in part [#161925392 - new SME archive view/page](https://www.pivotaltracker.com/story/show/161925392). Further changes will likely be needed (and theming definitely will), but this gives us a solid starting point for team review and iteration.

## Checklist

I have…

- [x] run the application locally (`make up`) and verified that my changes behave as expected.
- [x] run static behat test suite (`circleci build --job behat`) against my changes.
- [x] run the code sniffer (`circleci build --job code-sniffer`) against my changes.
- [x] run the code coverage tool (`circleci build --job code-coverage`) 
      against my changes
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/Bixal/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Creates a new "SME Document" content type. Includes the fields indicated in the corresponding ticket - Title, ID, Updated Date, Archive/Expiration Date, and the File itself. Adds an "SME Section" taxonomy reference field.
- Customizes the form and view display modes to match structural/UI needs.
- Adds a template for the Teaser display mode that uses the Title as the text for the file's download link and adds file size accessed in Twig through the File field's metadata.
- Creates a new "SME Section" Taxonomy vocabulary, where terms corresponding to each section can be added as content ([see Pivotal for details](https://www.pivotaltracker.com/story/show/161923738))
- Creates a new "SME Section" view, and a bunch of block displays containing the content of SME Documents in Teaser view mode, each display filtered by a corresponding SME Section taxonomy term.
- Places the various blocks corresponding with the view displays in the Content section of page layout, in the order matching ticket instructions and each restricted to "/sme-page".
- In the new view, adds Archive versions of each block display AND a single Archive page display that does not include taxonomy filters. We will want to use one or the other, not both.
- Adds a new "SME Sections" menu meant to contain links to each section's id (already being generated through existing code), places it in the left sidebar and restricts it to "/sme-page". If we build the Archive page similarly, we can also use it there.

## Testing

To verify the changes proposed in this pull request…
_(tentative, this is an educated guess)_ 

1. Pull code and import config. No need to rebuild theme assets at this time.
1. Create a blank Basic page with whatever Title you want and set the custom URL to "/sme-page" (we'll change it to /sme later, once we're ready to replace the existing one).
1. Create the specified terms ("Personal Property", "Advisories", etc) within the SME Section taxonomy vocabulary
1. Add sidebar menu items, linking to each section block's id, as outlined in the section above.
1. Upload one or more items and their corresponding data as SME Document content. Ideally, do enough to verify multiple items appear in the same section and that items in different sections appear properly. 

## Screenshots

New Page on my local with some content: 
<img width="1009" alt="dynamic sme page - local prelim" src="https://user-images.githubusercontent.com/29130580/49096144-ebeb7580-f237-11e8-904a-b0382f533965.png">
