### PR TITLE
Upgrade to PHP 7.4

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -33,7 +33,7 @@ MARIADB_TAG=10.1-3.3.4
 
 # macOS (uid 501 gid 20)
 
-PHP_TAG=7.3-dev-macos-4.15.0
+PHP_TAG=7.4-dev-macos-4.15.5
 
 ### --- NGINX ----
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# build site dependencies from debian stretch php 7.3 image
-FROM php:7.3-stretch as builder
+# build site dependencies from debian stretch php 7.4 image
+FROM php:7.4-stretch as builder
 
 ENV DART_SASS_VERSION 1.7.0
 
@@ -67,7 +67,7 @@ RUN composer dump-autoload --optimize && \
         composer run-script post-install-cmd
 
 # build the server from debian stretch and nginx 1.16 stable
-FROM php:7.3-fpm-stretch
+FROM php:7.4-fpm-stretch
 
 # non root user to run the server after binding sockets as root
 ENV NGINX_DOC_ROOT /var/www/html/web


### PR DESCRIPTION
This PR upgrades the version of PHP to 7.4. 

## Summary of Changes

This pull request upgrades both the docker build image and running container images to PHP 7.4. I've so far tested by running an instance of the site locally, and checked for any errors in the logs. 

