### PR TITLE
Plumbing ECR image scanning and deployment via CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,25 @@
 
 orbs:
   aws-ecr: circleci/aws-ecr@6.12.2
-  aws-cli: circleci/aws-cli@1.3.0
   ecr-image-scan-findings: trussworks/orb-ecr-image-scan-findings@1.1.1
 
+commands:
+  deploy_app_steps:
+    parameters:
+      environment:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Update image tag to deploy
+          command: |
+            CONFIG=$(jq ".Image = {Update: true, Name: \"${AWS_ECR_ACCOUNT_URL}/${ECR_REPO}:${CIRCLE_SHA1}\"}" Dockerrun.aws.json)
+            echo ${CONFIG} > Dockerrun.aws.json
+            git add Dockerrun.aws.json
+      - run:
+          name: EB Deploy
+          command: >
+            eb deploy milmove-<< parameters.environment >> --staged
 
 # Reusable steps.
 ## Defines images and working directory.
@@ -155,7 +171,6 @@ build_image: &build_image
   machine: true
   steps:
     - checkout
-    - aws-cli/install
     - aws-ecr/build-and-push-image:
         account-url: AWS_ECR_ACCOUNT_URL
         aws-access-key-id: AWS_ACCESS_KEY_ID
@@ -167,25 +182,6 @@ build_image: &build_image
         repo: "${ECR_REPO}"
         tag: "${CIRCLE_SHA1}"
 
-eb_deploy: &eb_deploy
-  docker:
-    - image: cimg/python:3.8
-  steps:
-    - checkout
-    - run:
-        name: Install AWS EB CLI
-        command: |
-          pip install awsebcli --upgrade --user
-    - run:
-        name: Update image to deploy
-        command: |
-          CONFIG=$(jq ".Image = {Update: true, Name: \"${AWS_ECR_ACCOUNT_URL}/${ECR_REPO}:${CIRCLE_SHA1}\"}" Dockerrun.aws.json)
-          echo ${CONFIG} > Dockerrun.aws.json
-          git add Dockerrun.aws.json
-    - run:
-        name: EB Deploy
-        command: >
-          eb deploy movemil-dynatest --staged
 
 version: 2.1
 jobs:
@@ -197,8 +193,13 @@ jobs:
     <<: *code_coverage
   build-image:
     <<: *build_image
-  eb-deploy:
-    <<: *eb_deploy
+  deploy-app-stg:
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - deploy_app_steps:
+          environment: stg
+
 
 workflows:
   version: 2.1
@@ -217,13 +218,13 @@ workflows:
             - build-image
           ecr-repository-name: ${ECR_REPO}
 
-      - eb-deploy:
+      - deploy-app-stg:
           requires:
             - behat
             - code-sniffer
             - code-coverage
             - build-image
-            - ecr-image-scan-findings/scan
+            #- ecr-image-scan-findings/scan don't block deploys on scan yet
           #filters:
           #  branches:
           #    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ commands:
     parameters:
       environment:
         type: string
+      url:
+        type: string
     steps:
       - checkout
       - run:
@@ -25,6 +27,9 @@ commands:
           name: EB Deploy
           command: >
             eb deploy << parameters.environment >> --staged
+      - run:
+          name: Health check app site
+          command: for retry in `seq 1 10`; do if curl -k -f -sS -o /dev/null << parameters.url >>; then echo Passed.; exit 0; else sleep $(($retry*3)); fi; done; exit 1
 
 # Reusable steps.
 ## Defines images and working directory.
@@ -202,6 +207,7 @@ jobs:
     steps:
       - deploy_app_steps:
           environment: movemil-stg
+          url: https://movemil-stg.us-east-1.elasticbeanstalk.com/
 
 workflows:
   version: 2.1
@@ -227,6 +233,6 @@ workflows:
             - code-coverage
             - build-image
             #- ecr-image-scan-findings/scan don't block deploys on scan yet
-          filters:
-            branches:
-              only: master
+          #filters:
+          #  branches:
+          #    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 # Runs a set of CI jobs for Drupal 8 projects.
 
+orbs:
+  aws-ecr: circleci/aws-ecr@6.12.2
+  aws-cli: circleci/aws-cli@1.3.0
+
 # Reusable steps.
 ## Defines images and working directory.
 defaults: &defaults
@@ -145,100 +149,22 @@ code_coverage: &code_coverage
         path: /var/www/html/artifacts
     - save_cache: *save_cache
 
-## Build stage image
-build_stage_image: &build_stage_image
-  docker:
-    - image: python:3.6.6
-  steps:
-    - checkout
-    - setup_remote_docker:
-        docker_layer_caching: false
-    - run:
-        name: Install dependencies
-        command: |
-          apt-get update \
-            && apt-get install -y \
-              unzip
-    - run:
-        name: Install Docker client
-        command: |
-          set -x
-          VER="18.03.1-ce"
-          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-          mv /tmp/docker/* /usr/bin
-    - run:
-        name: Install AWSCLI
-        command: |
-          curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-          unzip awscli-bundle.zip
-          ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-    - run:
-        name: Install AWS EB CLI
-        command: |
-          pip install awsebcli --upgrade --user
-    - run:
-        name: Python PATH
-        command: |
-            echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
-            source ~/.bashrc
-    - run:
-        name: "Log in to AWS ECR"
-        command: eval $(aws ecr get-login --region us-east-1 --no-include-email)
-
-    - run:
-        name: "Build & Push Docker Image"
-        command: |
-          docker build --build-arg GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/movemil:stage -f docker/Dockerfile .
-          docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/movemil:stage
-
-## Build production Image
-build_production_image: &build_production_image
-  docker:
-    - image: python:3.6.6
-  steps:
-    - checkout
-    - setup_remote_docker:
-        docker_layer_caching: false
-    - run:
-        name: Install dependencies
-        command: |
-          apt-get update \
-            && apt-get install -y \
-              unzip
-    - run:
-        name: Install Docker client
-        command: |
-          set -x
-          VER="18.03.1-ce"
-          curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-          tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-          mv /tmp/docker/* /usr/bin
-    - run:
-        name: Install AWSCLI
-        command: |
-          curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-          unzip awscli-bundle.zip
-          ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-    - run:
-        name: Install AWS EB CLI
-        command: |
-          pip install awsebcli --upgrade --user
-    - run:
-        name: Python PATH
-        command: |
-            echo 'export PATH=$HOME/.local/bin:$PATH' >> $BASH_ENV
-            source ~/.bashrc
-    - run:
-        name: "Log in to AWS ECR"
-        command: eval $(aws ecr get-login --region us-east-1 --no-include-email)
-
-    - run:
-        name: "Build & Push Docker Image"
-        command: |
-          docker build --build-arg GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY -t $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/movemil:production -f docker/Dockerfile .
-          docker push $AWS_ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/movemil:production
-
+build_image: &build_image
+  build:
+    machine: true
+    steps:
+      - checkout
+      - aws-cli/install
+      - aws-ecr/build-and-push-image:
+          account-url: AWS_ECR_ACCOUNT_URL
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          checkout: false
+          dockerfile: docker/Dockerfile
+          extra-build-args: "GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY"
+          region: AWS_DEFAULT_REGION
+          repo: move-dot-mil
+          tag: "${CIRCLE_SHA1}"
 
 # Declare all of the jobs we should run.
 version: 2
@@ -249,10 +175,8 @@ jobs:
     <<: *code_sniffer
   code-coverage:
     <<: *code_coverage
-  build-stage-image:
-    <<: *build_stage_image
-  build-production-image:
-    <<: *build_production_image
+  build-image:
+    <<: *build_image
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
@@ -262,15 +186,4 @@ workflows:
       - behat
       - code-sniffer
       - code-coverage
-  build_stage_image:
-    jobs:
-      - build-stage-image:
-          filters:
-            branches:
-              only: 1.x-dev
-  build_production_image:
-    jobs:
-      - build-production-image:
-          filters:
-            branches:
-              only: master
+      - build-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,13 +179,12 @@ eb_deploy: &eb_deploy
         command: |
           CONFIG=$(jq ".Image = {Update: true, Name: \"${AWS_ECR_ACCOUNT_URL}/${ECR_REPO}:${CIRCLE_SHA1}\"}" Dockerrun.aws.json)
           echo ${CONFIG} > Dockerrun.aws.json
-          cat Dockerrun.aws.json
+          git add Dockerrun.aws.json
     - run:
         name: EB Deploy
         command: >
-          eb deploy movemil-dynatest
+          eb deploy movemil-dynatest --staged
 
-# Declare all of the jobs we should run.
 version: 2.1
 jobs:
   behat:
@@ -199,10 +198,9 @@ jobs:
   eb-deploy:
     <<: *eb_deploy
 
-# Declare a workflow that runs all of our jobs in parallel.
 workflows:
   version: 2.1
-  test_and_lint:
+  app:
     jobs:
       - behat
       - code-sniffer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,6 @@ workflows:
             - code-coverage
             - build-image
             #- ecr-image-scan-findings/scan don't block deploys on scan yet
-          #filters:
-          #  branches:
-          #    only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@
 orbs:
   aws-ecr: circleci/aws-ecr@6.12.2
   aws-cli: circleci/aws-cli@1.3.0
-  ecr-image-scan-findings: trussworks/orb-ecr-image-scan-findings@1.0.1
+  ecr-image-scan-findings: trussworks/orb-ecr-image-scan-findings@1.1.1
+
 
 # Reusable steps.
 ## Defines images and working directory.
@@ -215,8 +216,6 @@ workflows:
           requires:
             - build-image
           ecr-repository-name: ${ECR_REPO}
-          aws-role-arn: ""
-          aws-role-session-name: ""
 
       - eb-deploy:
           requires:
@@ -224,6 +223,7 @@ workflows:
             - code-sniffer
             - code-coverage
             - build-image
+            - ecr-image-scan-findings/scan
           #filters:
           #  branches:
           #    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,14 +208,13 @@ workflows:
 
       - code-coverage
 
-      - build-image:
+      - build-image
+
+      - eb-deploy:
           requires:
             - behat
             - code-sniffer
             - code-coverage
-
-      - eb-deploy:
-          requires:
             - build-image
           #filters:
           #  branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,6 @@ workflows:
             - code-coverage
             - build-image
             #- ecr-image-scan-findings/scan don't block deploys on scan yet
-          #filters:
-          #  branches:
-          #    only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@
 orbs:
   aws-ecr: circleci/aws-ecr@6.12.2
   aws-cli: circleci/aws-cli@1.3.0
+  ecr-image-scan-findings: trussworks/orb-ecr-image-scan-findings@1.0.1
 
 # Reusable steps.
 ## Defines images and working directory.
@@ -162,7 +163,7 @@ build_image: &build_image
         dockerfile: docker/Dockerfile
         extra-build-args: "--build-arg GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY"
         region: AWS_DEFAULT_REGION
-        repo: move-dot-mil
+        repo: "${ECR_REPO}"
         tag: "${CIRCLE_SHA1}"
 
 eb_deploy: &eb_deploy
@@ -209,6 +210,13 @@ workflows:
       - code-coverage
 
       - build-image
+
+      - ecr-image-scan-findings/scan:
+          requires:
+            - build-image
+          ecr-repository-name: ${ECR_REPO}
+          aws-role-arn: ""
+          aws-role-session-name: ""
 
       - eb-deploy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@
 orbs:
   aws-ecr: circleci/aws-ecr@6.12.2
   aws-cli: circleci/aws-cli@1.3.0
-  awsebcli: sbc-orbs/awsebcli@0.0.3
 
 # Reusable steps.
 ## Defines images and working directory.
@@ -167,20 +166,24 @@ build_image: &build_image
         tag: "${CIRCLE_SHA1}"
 
 eb_deploy: &eb_deploy
-  machine: true
+  docker:
+    - image: cimg/python:3.8
   steps:
     - checkout
-    - awsebcli/install
+    - run:
+        name: Install AWS EB CLI
+        command: |
+          pip install awsebcli --upgrade --user
     - run:
         name: Update image to deploy
-        command: >
-          IMAGE="${AWS_ECR_ACCOUNT_URL}/${AWS_ECR_REPO}:${CIRCLE_SHA1}"
-          CONFIG=$(jq ".Image = {Update: true, Name: \"${IMAGE}\"}" Dockerrun.aws.json)
-          echo $CONFIG > Dockerrun.aws.json
+        command: |
+          CONFIG=$(jq ".Image = {Update: true, Name: \"${AWS_ECR_ACCOUNT_URL}/${ECR_REPO}:${CIRCLE_SHA1}\"}" Dockerrun.aws.json)
+          echo ${CONFIG} > Dockerrun.aws.json
+          cat Dockerrun.aws.json
     - run:
         name: EB Deploy
         command: >
-          eb deploy movemil-dynatest --staged
+          eb deploy movemil-dynatest
 
 # Declare all of the jobs we should run.
 version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ commands:
     steps:
       - checkout
       - run:
+          name: Install AWS EB CLI
+          command: |
+            pip install awsebcli --upgrade --user
+      - run:
           name: Update image tag to deploy
           command: |
             CONFIG=$(jq ".Image = {Update: true, Name: \"${AWS_ECR_ACCOUNT_URL}/${ECR_REPO}:${CIRCLE_SHA1}\"}" Dockerrun.aws.json)
@@ -20,7 +24,7 @@ commands:
       - run:
           name: EB Deploy
           command: >
-            eb deploy milmove-<< parameters.environment >> --staged
+            eb deploy << parameters.environment >> --staged
 
 # Reusable steps.
 ## Defines images and working directory.
@@ -182,7 +186,6 @@ build_image: &build_image
         repo: "${ECR_REPO}"
         tag: "${CIRCLE_SHA1}"
 
-
 version: 2.1
 jobs:
   behat:
@@ -198,8 +201,7 @@ jobs:
       - image: cimg/python:3.8
     steps:
       - deploy_app_steps:
-          environment: stg
-
+          environment: movemil-stg
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,20 @@ workflows:
   app:
     jobs:
       - behat
+
       - code-sniffer
+
       - code-coverage
-      - build-image
-      - eb-deploy
+
+      - build-image:
+          requires:
+            - behat
+            - code-sniffer
+            - code-coverage
+
+      - eb-deploy:
+          requires:
+            - build-image
+          #filters:
+          #  branches:
+          #    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@
 orbs:
   aws-ecr: circleci/aws-ecr@6.12.2
   aws-cli: circleci/aws-cli@1.3.0
+  awsebcli: sbc-orbs/awsebcli@0.0.3
 
 # Reusable steps.
 ## Defines images and working directory.
@@ -165,6 +166,22 @@ build_image: &build_image
         repo: move-dot-mil
         tag: "${CIRCLE_SHA1}"
 
+eb_deploy: &eb_deploy
+  machine: true
+  steps:
+    - checkout
+    - awsebcli/install
+    - run:
+        name: Update image to deploy
+        command: >
+          IMAGE="${AWS_ECR_ACCOUNT_URL}/${AWS_ECR_REPO}:${CIRCLE_SHA1}"
+          CONFIG=$(jq ".Image = {Update: true, Name: \"${IMAGE}\"}" Dockerrun.aws.json)
+          echo $CONFIG > Dockerrun.aws.json
+    - run:
+        name: EB Deploy
+        command: >
+          eb deploy movemil-dynatest --staged
+
 # Declare all of the jobs we should run.
 version: 2.1
 jobs:
@@ -176,6 +193,8 @@ jobs:
     <<: *code_coverage
   build-image:
     <<: *build_image
+  eb-deploy:
+    <<: *eb_deploy
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
@@ -186,3 +205,4 @@ workflows:
       - code-sniffer
       - code-coverage
       - build-image
+      - eb-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,24 +150,23 @@ code_coverage: &code_coverage
     - save_cache: *save_cache
 
 build_image: &build_image
-  build:
-    machine: true
-    steps:
-      - checkout
-      - aws-cli/install
-      - aws-ecr/build-and-push-image:
-          account-url: AWS_ECR_ACCOUNT_URL
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          checkout: false
-          dockerfile: docker/Dockerfile
-          extra-build-args: "GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY"
-          region: AWS_DEFAULT_REGION
-          repo: move-dot-mil
-          tag: "${CIRCLE_SHA1}"
+  machine: true
+  steps:
+    - checkout
+    - aws-cli/install
+    - aws-ecr/build-and-push-image:
+        account-url: AWS_ECR_ACCOUNT_URL
+        aws-access-key-id: AWS_ACCESS_KEY_ID
+        aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+        checkout: false
+        dockerfile: docker/Dockerfile
+        extra-build-args: "--build-arg GOOGLE_MAPS_API_KEY=$GOOGLE_MAPS_API_KEY"
+        region: AWS_DEFAULT_REGION
+        repo: move-dot-mil
+        tag: "${CIRCLE_SHA1}"
 
 # Declare all of the jobs we should run.
-version: 2
+version: 2.1
 jobs:
   behat:
     <<: *behat_tests
@@ -180,7 +179,7 @@ jobs:
 
 # Declare a workflow that runs all of our jobs in parallel.
 workflows:
-  version: 2
+  version: 2.1
   test_and_lint:
     jobs:
       - behat

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,9 +1,5 @@
 {
   "AWSEBDockerrunVersion": "1",
-  "Image": {
-    "Name": "328180890751.dkr.ecr.us-east-1.amazonaws.com/movemil:production",
-    "Update": "true"
-  },
   "Ports": [
     {
       "ContainerPort": "80"

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -11,5 +11,9 @@
       "ContainerDirectory": "/var/www/html/web/sites/default/files"
     }
   ],
-  "Logging": "/var/log/apache2"
+  "Logging": "/var/log/apache2",
+  "Image": {
+    "Name": "<image_name>",
+    "Update": "true"
+  }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -189,10 +189,7 @@ RUN mv drush.phar /usr/local/bin/drush
 RUN chmod +x /usr/local/bin/drush
 
 # copy in the files that the builder image built for drupal
-COPY --from=builder /var/www/html /var/www/html
-
-# make nginx able to access web root
-RUN chown -R www-data:www-data /var/www/html
+COPY --chown=www-data:www-data --from=builder /var/www/html /var/www/html
 
 EXPOSE 80
 


### PR DESCRIPTION
This PR does a couple of things on the container image and deployment front. 

1) Replaces the bespoke image building and pushing circleci config with the circleci/aws-ecr orb
2) Adds the Truss built ecr image scanning orb to the pipeline. It's got known vulnerabilities and is expected to be red.
3) It modifies deploys from using a single tagged docker image (:production) with a git tag approach. It deploys to a newly created milmove-stg environment. There will be follow on work to make this more authoritative. 
4) Slight simplification to the Dockerfile which ended up cutting build times in half (15min vs 8).

