### PR TITLE
Switch from Debian Buster to Alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,6 @@ workflows:
             - code-coverage
             - build-image
             - ecr-image-scan-findings/scan
-          #filters:
-          #  branches:
-          #    only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,6 @@ workflows:
             - code-coverage
             - build-image
             #- ecr-image-scan-findings/scan don't block deploys on scan yet
-          filters:
-            branches:
-              only: master
+          #filters:
+          #  branches:
+          #    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ workflows:
             - code-sniffer
             - code-coverage
             - build-image
-            #- ecr-image-scan-findings/scan don't block deploys on scan yet
+            - ecr-image-scan-findings/scan
           #filters:
           #  branches:
           #    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,6 @@ workflows:
             - code-coverage
             - build-image
             - ecr-image-scan-findings/scan
-          filters:
-            branches:
-              only: master
+          #filters:
+          #  branches:
+          #    only: master

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,43 +1,73 @@
-# build site dependencies from debian buster php 7.4 image
-FROM php:7.4-buster as builder
+# Set global versions and checksums
+# GitHub
+ARG DRUPAL_CONSOLE_VERSION=1.8.0
+ARG DRUPAL_CONSOLE_SHA256SUM=1c9bef3d3e4f70633d5004e3a3d86d90630df7cf97dab46d0175855796f934da
+ARG DRUSH_VERSION=0.6.0
+ARG DRUSH_SHA256SUM=c3f32a800a2f18470b0010cd71c49e49ef5c087f8131eecfe9b686dc1f3f3d4e
+ARG DART_SASS_VERSION=1.26.10
+ARG DART_SASS_SHA256SUM=2eed8cf8ec08e59e14c3801819aacc296f09524dad10af4a886412053af45b82
 
-ENV DART_SASS_VERSION 1.26.10
+# Apk
+ARG ZLIB_DEV_VERSION=1.2.11-r3
+ARG LIBPNG_DEV_VERSION=1.6.37-r1
+ARG LIBZIP_VERSION=1.5.2-r0
+ARG NODEJS_VERION=12.15.0-r1
+ARG GIT_VERSION=2.24.3-r0
+ARG MYSQL_CLIENT_VERSION=10.4.13-r0
+ARG NGINX_VERSION=1.16.1-r6
+ARG SUPERVISOR_VERSION=4.1.0-r0
+
+# PHP Composer
+ARG COMPOSER_VERSION=1.10.10
+
+# ECR image scaning doesn't currently support Alpine 3.12, so we need to stick
+# to 3.11.
+# https://github.com/aws/containers-roadmap/issues/963
+FROM php:7.4-alpine3.11 as builder
+
+# load the versions and checksums needed in this stage
+ARG COMPOSER_VERSION
+ARG ZLIB_DEV_VERSION
+ARG LIBPNG_DEV_VERSION
+ARG LIBZIP_VERSION
+ARG NODEJS_VERION
+ARG GIT_VERSION
+ARG MYSQL_CLIENT_VERSION
+ARG DART_SASS_VERSION
+ARG DART_SASS_SHA256SUM
 
 ARG GOOGLE_MAPS_API_KEY
 
-RUN apt-get update && apt-get install -y gnupg
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt-get update && apt-get install -y --no-install-recommends \
-	libzip-dev \
-	build-essential \
-	libfreetype6-dev \
-	libjpeg62-turbo-dev \
-	libmcrypt-dev \
-	libpng-dev \
-	default-mysql-client \
-	git \
-	nodejs \
-	&& docker-php-ext-install \
+RUN set -ex \
+	&& curl -sSLO https://getcomposer.org/installer \
+	&& curl -sSLO https://composer.github.io/installer.sig \
+	&& php -r "if (hash_file('sha384', 'installer') === file_get_contents('installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+	&& php installer --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} \
+	&& rm installer installer.sig
+
+RUN apk add --update --no-cache \
+	zlib-dev="$ZLIB_DEV_VERSION" \
+	libpng-dev="$LIBPNG_DEV_VERSION" \
+	libzip-dev="$LIBZIP_VERSION" \
+	nodejs="$NODEJS_VERION" \
+	npm="$NODEJS_VERION" \
+	git="$GIT_VERSION" \
+	&& rm -rf /var/cache/apk/*
+
+RUN docker-php-ext-install -j "$(nproc)" \
 	gd \
 	opcache \
 	pdo \
 	pdo_mysql \
 	zip
 
-
-RUN rm -rf /var/lib/apt/lists/*
-
-ENV COMPOSER_COMMIT 877cb10b101957ef8bbb9d196f711dbb8a011bb4
-RUN curl -o composer-setup.php --remote-name "https://raw.githubusercontent.com/composer/getcomposer.org/$COMPOSER_COMMIT/web/installer" | php -- --quiet > 'composer-setup.php' \
-    && php -r "if (hash_file('SHA384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
-    && php -r "unlink('composer-setup.php');"
-
 WORKDIR /root
 
-RUN curl -L --remote-name https://github.com/sass/dart-sass/releases/download/$DART_SASS_VERSION/dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
-RUN tar xzf dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz && rm dart-sass-$DART_SASS_VERSION-linux-x64.tar.gz
-
+RUN set -ex \
+	&& curl -sSLO https://github.com/sass/dart-sass/releases/download/"$DART_SASS_VERSION"/dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz \
+	&& [ $(sha256sum dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz | cut -f1 -d' ') = "$DART_SASS_SHA256SUM" ] \
+	&& tar xzf dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz \
+	&& rm dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz
 ENV PATH="/root/dart-sass:$PATH"
 
 # The following section is all in the name of container caching. We copy over the code base AFTER building deps.
@@ -64,36 +94,39 @@ COPY . /var/www/html
 
 WORKDIR /var/www/html
 
-RUN composer dump-autoload --optimize && \
-	composer run-script post-install-cmd
+RUN composer dump-autoload --optimize \
+	&& composer run-script post-install-cmd
 
 # ECR image scaning doesn't currently support Alpine 3.12, so we need to stick
 # to 3.11.
 # https://github.com/aws/containers-roadmap/issues/963
 FROM php:7.4-fpm-alpine3.11
 
+# load the versions and checksums needed in this stage
+ARG DRUPAL_CONSOLE_VERSION
+ARG DRUPAL_CONSOLE_SHA256SUM
+ARG DRUSH_VERSION
+ARG DRUSH_SHA256SUM
+ARG ZLIB_DEV_VERSION
+ARG LIBPNG_DEV_VERSION
+ARG LIBZIP_VERSION
+ARG MYSQL_CLIENT_VERSION
+ARG NGINX_VERSION
+ARG SUPERVISOR_VERSION
+
 # non root user to run the server after binding sockets as root
 ENV NGINX_DOC_ROOT /var/www/html/web
-
-ENV DRUPAL_CONSOLE_VERSION 1.8.0
-ENV DRUSH_VERSION          0.6.0
-ENV NGINX_VERSION          1.16.1-r6
-ENV SUPERVISOR_VERSION     4.1.0-r0
-ENV ZLIB_DEV_VERSION       1.2.11-r3
-ENV LIBPNG_DEV_VERSION     1.6.37-r1
-ENV LIBZIP_VERSION         1.5.2-r0
-ENV MYSQL_CLIENT_VERSION   10.4.13-r0
 
 WORKDIR /var/www/html
 
 RUN apk add --update --no-cache \
-	nginx=$NGINX_VERSION \
-	supervisor=$SUPERVISOR_VERSION\
-	zlib-dev=$ZLIB_DEV_VERSION \
-	libpng-dev=$LIBPNG_DEV_VERSION \
-	libzip-dev=$LIBZIP_VERSION \
-	mysql-client=$MYSQL_CLIENT_VERSION && \
-	rm -rf /var/cache/apk/*
+	nginx="$NGINX_VERSION" \
+	supervisor="$SUPERVISOR_VERSION"\
+	zlib-dev="$ZLIB_DEV_VERSION" \
+	libpng-dev="$LIBPNG_DEV_VERSION" \
+	libzip-dev="$LIBZIP_VERSION" \
+	mysql-client="$MYSQL_CLIENT_VERSION" \
+	&& rm -rf /var/cache/apk/*
 
 RUN docker-php-ext-install -j "$(nproc)" \
 	gd \
@@ -106,13 +139,17 @@ COPY docker/php/php.ini /usr/local/etc/php
 COPY docker/supervisord.conf /etc/
 COPY docker/nginx.conf /etc/nginx/
 
-RUN curl https://github.com/hechoendrupal/drupal-console-launcher/releases/download/$DRUPAL_CONSOLE_VERSION/drupal.phar -L -o drupal.phar
-RUN mv drupal.phar /usr/local/bin/drupal
-RUN chmod +x /usr/local/bin/drupal
+RUN set -ex \
+	&& curl -sSLO https://github.com/hechoendrupal/drupal-console-launcher/releases/download/"$DRUPAL_CONSOLE_VERSION"/drupal.phar \
+	&& [ $(sha256sum dart-sass-"$DRUPAL_CONSOLE_VERSION"-linux-x64.tar.gz | cut -f1 -d' ') = "$DRUPAL_CONSOLE_SHA256SUM" ] \
+	&& mv drupal.phar /usr/local/bin/drupal \
+	&& chmod +x /usr/local/bin/drupal
 
-RUN curl https://github.com/drush-ops/drush-launcher/releases/download/$DRUSH_VERSION/drush.phar -L -o drush.phar
-RUN mv drush.phar /usr/local/bin/drush
-RUN chmod +x /usr/local/bin/drush
+RUN set -ex \
+	&& curl -sSLO https://github.com/drush-ops/drush-launcher/releases/download/"$DRUSH_VERSION"/drush.phar \
+	&& [ $(sha256sum dart-sass-"$DRUPAL_CONSOLE_VERSION"-linux-x64.tar.gz | cut -f1 -d' ') = "$DRUPAL_CONSOLE_SHA256SUM" ] \
+	&& mv drush.phar /usr/local/bin/drush \
+	&& chmod +x /usr/local/bin/drush
 
 # copy in the files that the builder image built for drupal
 COPY --chown=www-data:www-data --from=builder /var/www/html /var/www/html

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,6 +67,9 @@ WORKDIR /var/www/html
 RUN composer dump-autoload --optimize && \
 	composer run-script post-install-cmd
 
+# ECR image scaning doesn't currently support Alpine 3.12, so we need to stick
+# to 3.11.
+# https://github.com/aws/containers-roadmap/issues/963
 FROM php:7.4-fpm-alpine3.11
 
 # non root user to run the server after binding sockets as root
@@ -100,7 +103,6 @@ RUN docker-php-ext-install -j "$(nproc)" \
 COPY docker/php/php.ini /usr/local/etc/php
 COPY docker/supervisord.conf /etc/
 COPY docker/nginx.conf /etc/nginx/
-RUN mkdir -p /run/nginx
 
 RUN curl https://github.com/hechoendrupal/drupal-console-launcher/releases/download/$DRUPAL_CONSOLE_VERSION/drupal.phar -L -o drupal.phar
 RUN mv drupal.phar /usr/local/bin/drupal

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,35 +39,35 @@ ARG DART_SASS_SHA256SUM
 ARG GOOGLE_MAPS_API_KEY
 
 RUN set -ex \
-	&& curl -sSLO https://getcomposer.org/installer \
-	&& curl -sSLO https://composer.github.io/installer.sig \
-	&& php -r "if (hash_file('sha384', 'installer') === file_get_contents('installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-	&& php installer --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} \
-	&& rm installer installer.sig
+        && curl -sSLO https://getcomposer.org/installer \
+        && curl -sSLO https://composer.github.io/installer.sig \
+        && php -r "if (hash_file('sha384', 'installer') === file_get_contents('installer.sig')) { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+        && php installer --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} \
+        && rm installer installer.sig
 
 RUN apk add --update --no-cache \
-	zlib-dev="$ZLIB_DEV_VERSION" \
-	libpng-dev="$LIBPNG_DEV_VERSION" \
-	libzip-dev="$LIBZIP_VERSION" \
-	nodejs="$NODEJS_VERION" \
-	npm="$NODEJS_VERION" \
-	git="$GIT_VERSION" \
-	&& rm -rf /var/cache/apk/*
+        zlib-dev="$ZLIB_DEV_VERSION" \
+        libpng-dev="$LIBPNG_DEV_VERSION" \
+        libzip-dev="$LIBZIP_VERSION" \
+        nodejs="$NODEJS_VERION" \
+        npm="$NODEJS_VERION" \
+        git="$GIT_VERSION" \
+        && rm -rf /var/cache/apk/*
 
 RUN docker-php-ext-install -j "$(nproc)" \
-	gd \
-	opcache \
-	pdo \
-	pdo_mysql \
-	zip
+        gd \
+        opcache \
+        pdo \
+        pdo_mysql \
+        zip
 
 WORKDIR /root
 
 RUN set -ex \
-	&& curl -sSLO https://github.com/sass/dart-sass/releases/download/"$DART_SASS_VERSION"/dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz \
-	&& [ $(sha256sum dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz | cut -f1 -d' ') = "$DART_SASS_SHA256SUM" ] \
-	&& tar xzf dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz \
-	&& rm dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz
+        && curl -sSLO https://github.com/sass/dart-sass/releases/download/"$DART_SASS_VERSION"/dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz \
+        && [ $(sha256sum dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz | cut -f1 -d' ') = "$DART_SASS_SHA256SUM" ] \
+        && tar xzf dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz \
+        && rm dart-sass-"$DART_SASS_VERSION"-linux-x64.tar.gz
 ENV PATH="/root/dart-sass:$PATH"
 
 # The following section is all in the name of container caching. We copy over the code base AFTER building deps.
@@ -95,7 +95,7 @@ COPY . /var/www/html
 WORKDIR /var/www/html
 
 RUN composer dump-autoload --optimize \
-	&& composer run-script post-install-cmd
+        && composer run-script post-install-cmd
 
 # ECR image scaning doesn't currently support Alpine 3.12, so we need to stick
 # to 3.11.
@@ -120,36 +120,36 @@ ENV NGINX_DOC_ROOT /var/www/html/web
 WORKDIR /var/www/html
 
 RUN apk add --update --no-cache \
-	nginx="$NGINX_VERSION" \
-	supervisor="$SUPERVISOR_VERSION"\
-	zlib-dev="$ZLIB_DEV_VERSION" \
-	libpng-dev="$LIBPNG_DEV_VERSION" \
-	libzip-dev="$LIBZIP_VERSION" \
-	mysql-client="$MYSQL_CLIENT_VERSION" \
-	&& rm -rf /var/cache/apk/*
+        nginx="$NGINX_VERSION" \
+        supervisor="$SUPERVISOR_VERSION"\
+        zlib-dev="$ZLIB_DEV_VERSION" \
+        libpng-dev="$LIBPNG_DEV_VERSION" \
+        libzip-dev="$LIBZIP_VERSION" \
+        mysql-client="$MYSQL_CLIENT_VERSION" \
+        && rm -rf /var/cache/apk/*
 
 RUN docker-php-ext-install -j "$(nproc)" \
-	gd \
-	opcache \
-	pdo \
-	pdo_mysql \
-	zip
+        gd \
+        opcache \
+        pdo \
+        pdo_mysql \
+        zip
 
 COPY docker/php/php.ini /usr/local/etc/php
 COPY docker/supervisord.conf /etc/
 COPY docker/nginx.conf /etc/nginx/
 
 RUN set -ex \
-	&& curl -sSLO https://github.com/hechoendrupal/drupal-console-launcher/releases/download/"$DRUPAL_CONSOLE_VERSION"/drupal.phar \
-	&& [ $(sha256sum dart-sass-"$DRUPAL_CONSOLE_VERSION"-linux-x64.tar.gz | cut -f1 -d' ') = "$DRUPAL_CONSOLE_SHA256SUM" ] \
-	&& mv drupal.phar /usr/local/bin/drupal \
-	&& chmod +x /usr/local/bin/drupal
+        && curl -sSLO https://github.com/hechoendrupal/drupal-console-launcher/releases/download/"$DRUPAL_CONSOLE_VERSION"/drupal.phar \
+        && [ $(sha256sum drupal.phar | cut -f1 -d' ') = "$DRUPAL_CONSOLE_SHA256SUM" ] \
+        && mv drupal.phar /usr/local/bin/drupal \
+        && chmod +x /usr/local/bin/drupal
 
 RUN set -ex \
-	&& curl -sSLO https://github.com/drush-ops/drush-launcher/releases/download/"$DRUSH_VERSION"/drush.phar \
-	&& [ $(sha256sum dart-sass-"$DRUPAL_CONSOLE_VERSION"-linux-x64.tar.gz | cut -f1 -d' ') = "$DRUPAL_CONSOLE_SHA256SUM" ] \
-	&& mv drush.phar /usr/local/bin/drush \
-	&& chmod +x /usr/local/bin/drush
+        && curl -sSLO https://github.com/drush-ops/drush-launcher/releases/download/"$DRUSH_VERSION"/drush.phar \
+        && [ $(sha256sum drush.phar | cut -f1 -d' ') = "$DRUSH_SHA256SUM" ] \
+        && mv drush.phar /usr/local/bin/drush \
+        && chmod +x /usr/local/bin/drush
 
 # copy in the files that the builder image built for drupal
 COPY --chown=www-data:www-data --from=builder /var/www/html /var/www/html

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,19 +74,20 @@ ENV NGINX_DOC_ROOT /var/www/html/web
 
 ENV DRUPAL_CONSOLE_VERSION 1.8.0
 ENV DRUSH_VERSION          0.6.0
-ENV NGINX_VERSION          1.18.0-r0
-ENV SUPERVISOR_VERSION     4.1.0-r0 #4.2.0-r0
-ENV ZLIB_DEV_VERSION       1.2.11-r3 #1.2.11-r3
-ENV LIBPNG_DEV_VERSION     1.6.37-r1 #1.6.37-r1
-ENV LIBZIP_VERSION         1.5.2-r0 #1.6.1-r1
+ENV NGINX_VERSION          1.16.1-r6
+ENV SUPERVISOR_VERSION     4.1.0-r0
+ENV ZLIB_DEV_VERSION       1.2.11-r3
+ENV LIBPNG_DEV_VERSION     1.6.37-r1
+ENV LIBZIP_VERSION         1.5.2-r0
 
 WORKDIR /var/www/html
 
-RUN apk add --update --no-cache nginx \
-	supervisor \
-	zlib-dev \
-	libpng-dev \
-        libzip-dev && \
+RUN apk add --update --no-cache \
+	nginx=$NGINX_VERSION \
+	supervisor=$SUPERVISOR_VERSION\
+	zlib-dev=$ZLIB_DEV_VERSION \
+	libpng-dev=$LIBPNG_DEV_VERSION \
+        libzip-dev=$LIBZIP_VERSION && \
 	rm -rf /var/cache/apk/*
 
 RUN docker-php-ext-install -j "$(nproc)" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	git \
 	nodejs \
 	&& docker-php-ext-install \
-        gd \
-        opcache \
-        pdo \
-        pdo_mysql \
-        zip
+	gd \
+	opcache \
+	pdo \
+	pdo_mysql \
+	zip
 
 
 RUN rm -rf /var/lib/apt/lists/*
@@ -67,114 +67,34 @@ WORKDIR /var/www/html
 RUN composer dump-autoload --optimize && \
 	composer run-script post-install-cmd
 
-# build the server from debian buster and nginx 1.18 stable
-FROM php:7.4-fpm-buster
+FROM php:7.4-fpm-alpine3.12
 
 # non root user to run the server after binding sockets as root
 ENV NGINX_DOC_ROOT /var/www/html/web
+
 ENV DRUPAL_CONSOLE_VERSION 1.8.0
-ENV DRUSH_VERSION 0.6.0
-
-ENV NGINX_VERSION   1.18.0
-ENV NJS_VERSION     0.4.2
-ENV PKG_RELEASE     1~buster
-
-RUN set -x \
-	&& apt-get update \
-	&& apt-get install --no-install-recommends --no-install-suggests -y gnupg1 apt-transport-https ca-certificates \
-	&& \
-	NGINX_GPGKEY=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62; \
-	found=''; \
-	for server in \
-		ha.pool.sks-keyservers.net \
-		hkp://keyserver.ubuntu.com:80 \
-		hkp://p80.pool.sks-keyservers.net:80 \
-		pgp.mit.edu \
-	; do \
-		echo "Fetching GPG key $NGINX_GPGKEY from $server"; \
-		apt-key adv --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$NGINX_GPGKEY" && found=yes && break; \
-	done; \
-	test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
-	apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
-	&& dpkgArch="$(dpkg --print-architecture)" \
-	&& nginxPackages=" \
-		nginx=${NGINX_VERSION}-${PKG_RELEASE} \
-		nginx-module-xslt=${NGINX_VERSION}-${PKG_RELEASE} \
-		nginx-module-geoip=${NGINX_VERSION}-${PKG_RELEASE} \
-		nginx-module-image-filter=${NGINX_VERSION}-${PKG_RELEASE} \
-		nginx-module-njs=${NGINX_VERSION}.${NJS_VERSION}-${PKG_RELEASE} \
-	" \
-	&& case "$dpkgArch" in \
-		amd64|i386) \
-# arches officialy built by upstream
-			echo "deb https://nginx.org/packages/debian/ buster nginx" >> /etc/apt/sources.list.d/nginx.list \
-			&& apt-get update \
-			;; \
-		*) \
-# we're on an architecture upstream doesn't officially build for
-# let's build binaries from the published source packages
-			echo "deb-src https://nginx.org/packages/debian/ buster nginx" >> /etc/apt/sources.list.d/nginx.list \
-			\
-# new directory for storing sources and .deb files
-			&& tempDir="$(mktemp -d)" \
-			&& chmod 777 "$tempDir" \
-# (777 to ensure APT's "_apt" user can access it too)
-			\
-# save list of currently-installed packages so build dependencies can be cleanly removed later
-			&& savedAptMark="$(apt-mark showmanual)" \
-			\
-# build .deb files from upstream's source packages (which are verified by apt-get)
-			&& apt-get update \
-			&& apt-get build-dep -y $nginxPackages \
-			&& ( \
-				cd "$tempDir" \
-				&& DEB_BUILD_OPTIONS="nocheck parallel=$(nproc)" \
-					apt-get source --compile $nginxPackages \
-			) \
-# we don't remove APT lists here because they get re-downloaded and removed later
-			\
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
-			&& apt-mark showmanual | xargs apt-mark auto > /dev/null \
-			&& { [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; } \
-			\
-# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
-			&& ls -lAFh "$tempDir" \
-			&& ( cd "$tempDir" && dpkg-scanpackages . > Packages ) \
-			&& grep '^Package: ' "$tempDir/Packages" \
-			&& echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list \
-# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
-#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
-#   ...
-#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
-			&& apt-get -o Acquire::GzipIndexes=false update \
-			;; \
-	esac \
-	\
-	&& apt-get install --no-install-recommends --no-install-suggests -y \
-						$nginxPackages \
-						gettext-base \
-	&& apt-get remove --purge --auto-remove -y apt-transport-https ca-certificates && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/nginx.list \
-	\
-# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
-	&& if [ -n "$tempDir" ]; then \
-		apt-get purge -y --auto-remove \
-		&& rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
-	fi
+ENV DRUSH_VERSION          0.6.0
+ENV NGINX_VERSION          1.18.0-r0
+ENV SUPERVISOR_VERSION     4.2.0-r0
+ENV ZLIB_DEV_VERSION       1.2.11-r3
+ENV LIBPNG_DEV_VERSION     1.6.37-r1
+ENV LIBZIP_VERSION         1.6.1-r1
 
 WORKDIR /var/www/html
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    default-mysql-client \
-    libpng-dev \
-    libzip-dev \
-    ca-certificates \
-    supervisor \
-    && docker-php-ext-install gd \
-    opcache \
-    pdo \
-    pdo_mysql \
-    zip \
-    && rm -rf /var/lib/apt/lists/*
+
+RUN apk add --update --no-cache nginx=$NGINX_VERSION \
+	supervisor=$SUPERVISOR_VERSION \
+	zlib-dev=$ZLIB_DEV_VERSION \
+	libpng-dev=$LIBPNG_DEV_VERSION \
+        libzip-dev=$LIBZIP_VERSION && \
+	rm -rf /var/cache/apk/*
+
+RUN docker-php-ext-install -j$(nproc) \
+	gd \
+	opcache \
+	pdo \
+	pdo_mysql \
+	zip
 
 COPY docker/php/php.ini /usr/local/etc/php
 COPY docker/supervisord.conf /etc/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,18 +67,18 @@ WORKDIR /var/www/html
 RUN composer dump-autoload --optimize && \
 	composer run-script post-install-cmd
 
-FROM php:7.4-fpm-alpine3.12
+FROM php:7.4-fpm-alpine3.11
 
 # non root user to run the server after binding sockets as root
 ENV NGINX_DOC_ROOT /var/www/html/web
 
 ENV DRUPAL_CONSOLE_VERSION 1.8.0
 ENV DRUSH_VERSION          0.6.0
-ENV NGINX_VERSION          1.18.0-r0
-ENV SUPERVISOR_VERSION     4.2.0-r0
-ENV ZLIB_DEV_VERSION       1.2.11-r3
-ENV LIBPNG_DEV_VERSION     1.6.37-r1
-ENV LIBZIP_VERSION         1.6.1-r1
+ENV NGINX_VERSION          1.16.1-r6 #1.18.0-r0
+ENV SUPERVISOR_VERSION     4.1.0-r0 #4.2.0-r0
+ENV ZLIB_DEV_VERSION       1.2.11-r3 #1.2.11-r3
+ENV LIBPNG_DEV_VERSION     1.6.37-r1 #1.6.37-r1
+ENV LIBZIP_VERSION         1.5.2-r0 #1.6.1-r1
 
 WORKDIR /var/www/html
 
@@ -89,7 +89,7 @@ RUN apk add --update --no-cache nginx=$NGINX_VERSION \
         libzip-dev=$LIBZIP_VERSION && \
 	rm -rf /var/cache/apk/*
 
-RUN docker-php-ext-install -j$(nproc) \
+RUN docker-php-ext-install -j "$(nproc)" \
 	gd \
 	opcache \
 	pdo \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,6 +100,7 @@ RUN docker-php-ext-install -j "$(nproc)" \
 COPY docker/php/php.ini /usr/local/etc/php
 COPY docker/supervisord.conf /etc/
 COPY docker/nginx.conf /etc/nginx/
+RUN mkdir -p /run/nginx
 
 RUN curl https://github.com/hechoendrupal/drupal-console-launcher/releases/download/$DRUPAL_CONSOLE_VERSION/drupal.phar -L -o drupal.phar
 RUN mv drupal.phar /usr/local/bin/drupal

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,6 +82,7 @@ ENV SUPERVISOR_VERSION     4.1.0-r0
 ENV ZLIB_DEV_VERSION       1.2.11-r3
 ENV LIBPNG_DEV_VERSION     1.6.37-r1
 ENV LIBZIP_VERSION         1.5.2-r0
+ENV MYSQL_CLIENT_VERSION   10.4.13-r0
 
 WORKDIR /var/www/html
 
@@ -90,7 +91,8 @@ RUN apk add --update --no-cache \
 	supervisor=$SUPERVISOR_VERSION\
 	zlib-dev=$ZLIB_DEV_VERSION \
 	libpng-dev=$LIBPNG_DEV_VERSION \
-        libzip-dev=$LIBZIP_VERSION && \
+	libzip-dev=$LIBZIP_VERSION \
+	mysql-client=$MYSQL_CLIENT_VERSION && \
 	rm -rf /var/cache/apk/*
 
 RUN docker-php-ext-install -j "$(nproc)" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ ENV NGINX_DOC_ROOT /var/www/html/web
 
 ENV DRUPAL_CONSOLE_VERSION 1.8.0
 ENV DRUSH_VERSION          0.6.0
-ENV NGINX_VERSION          1.16.1-r6 #1.18.0-r0
+ENV NGINX_VERSION          1.18.0-r0
 ENV SUPERVISOR_VERSION     4.1.0-r0 #4.2.0-r0
 ENV ZLIB_DEV_VERSION       1.2.11-r3 #1.2.11-r3
 ENV LIBPNG_DEV_VERSION     1.6.37-r1 #1.6.37-r1
@@ -82,11 +82,11 @@ ENV LIBZIP_VERSION         1.5.2-r0 #1.6.1-r1
 
 WORKDIR /var/www/html
 
-RUN apk add --update --no-cache nginx=$NGINX_VERSION \
-	supervisor=$SUPERVISOR_VERSION \
-	zlib-dev=$ZLIB_DEV_VERSION \
-	libpng-dev=$LIBPNG_DEV_VERSION \
-        libzip-dev=$LIBZIP_VERSION && \
+RUN apk add --update --no-cache nginx \
+	supervisor \
+	zlib-dev \
+	libpng-dev \
+        libzip-dev && \
 	rm -rf /var/cache/apk/*
 
 RUN docker-php-ext-install -j "$(nproc)" \

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -14,6 +14,8 @@ error_log /var/log/nginx/error.log warn;
 # Includes files with directives to load dynamic modules.
 include /etc/nginx/modules/*.conf;
 
+# Run out of /tmp to allow nginx to run as a less privileged UID
+pid        /tmp/nginx.pid;
 
 events {
 	# The maximum number of simultaneous connections that can be opened by
@@ -22,7 +24,14 @@ events {
 }
 
 http {
-    # Includes mapping of file name extensions to MIME types of responses
+    # Run out of /tmp to allow nginx to run as a less privileged UID
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+   # Includes mapping of file name extensions to MIME types of responses
     # and defines the default type.
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
@@ -85,8 +94,8 @@ http {
 
     # Specifies the main log format.
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
+		    '$status $body_bytes_sent "$http_referer" '
+		    '"$http_user_agent" "$http_x_forwarded_for"';
 
     # Sets the path, format, and configuration for a buffered log write.
     access_log /var/log/nginx/access.log main;
@@ -102,127 +111,127 @@ http {
 
     # reject http requests that set both Content-Length and Transfer-Encoding header fields for the crlf injection vulnerability
     map "$http_content_length:$http_transfer_encoding" $crlf_vuln {
-        default "0";
-        ":chunked" "1";
+	default "0";
+	":chunked" "1";
     }
 
     server {
-        listen		80 default_server;
-        listen      [::]:80 default_server;
-        root		/var/www/html/web;
-        index		index.php index.html index.htm;
-        server_name	localhost;
-        client_max_body_size	32m;
+	listen		80 default_server;
+	listen      [::]:80 default_server;
+	root		/var/www/html/web;
+	index		index.php index.html index.htm;
+	server_name	localhost;
+	client_max_body_size	32m;
 
-        # use variable from above to reject and close without response the connection
-        if ($crlf_vuln) {
-           return 444;
-        }
-            
+	# use variable from above to reject and close without response the connection
+	if ($crlf_vuln) {
+	   return 444;
+	}
 
-        location = /favicon.ico {
+
+	location = /favicon.ico {
 		log_not_found off;
 		access_log off;
-        }
+	}
 
-        location = /robots.txt {
-            allow all;
-            log_not_found off;
-            access_log off;
-        }
+	location = /robots.txt {
+	    allow all;
+	    log_not_found off;
+	    access_log off;
+	}
 
-        # Very rarely should these ever be accessed outside of your lan
-        location ~* \.(txt|log)$ {
-            allow 192.168.0.0/16;
-            deny all;
-        }
+	# Very rarely should these ever be accessed outside of your lan
+	location ~* \.(txt|log)$ {
+	    allow 192.168.0.0/16;
+	    deny all;
+	}
 
-        location ~ \..*/.*\.php$ {
-            return 403;
-        }
+	location ~ \..*/.*\.php$ {
+	    return 403;
+	}
 
-        location ~ ^/sites/.*/private/ {
-            return 403;
-        }
+	location ~ ^/sites/.*/private/ {
+	    return 403;
+	}
 
-        # Block access to scripts in site files directory
-        location ~ ^/sites/[^/]+/files/.*\.php$ {
-            deny all;
-        }
+	# Block access to scripts in site files directory
+	location ~ ^/sites/[^/]+/files/.*\.php$ {
+	    deny all;
+	}
 
-        # Allow "Well-Known URIs" as per RFC 5785
-        location ~* ^/.well-known/ {
-            allow all;
-        }
+	# Allow "Well-Known URIs" as per RFC 5785
+	location ~* ^/.well-known/ {
+	    allow all;
+	}
 
-        # Block access to "hidden" files and directories whose names begin with a
-        # period. This includes directories used by version control systems such
-        # as Subversion or Git to store control files.
-        location ~ (^|/)\. {
-            return 403;
-        }
+	# Block access to "hidden" files and directories whose names begin with a
+	# period. This includes directories used by version control systems such
+	# as Subversion or Git to store control files.
+	location ~ (^|/)\. {
+	    return 403;
+	}
 
-        location / {
-            try_files $uri /index.php?$query_string;
-        }
+	location / {
+	    try_files $uri /index.php?$query_string;
+	}
 
-        location @rewrite {
-            rewrite ^/(.*)$ /index.php?q=$1;
-        }
+	location @rewrite {
+	    rewrite ^/(.*)$ /index.php?q=$1;
+	}
 
-        # Don't allow direct access to PHP files in the vendor directory.
-        location ~ /vendor/.*\.php$ {
-            deny all;
-            return 404;
-        }
+	# Don't allow direct access to PHP files in the vendor directory.
+	location ~ /vendor/.*\.php$ {
+	    deny all;
+	    return 404;
+	}
 
-        # In Drupal 8, we must also match new paths where the '.php' appears in
-        # the middle, such as update.php/selection. The rule we use is strict,
-        # and only allows this pattern with the update.php front controller.
-        # This allows legacy path aliases in the form of
-        # blog/index.php/legacy-path to continue to route to Drupal nodes. If
-        # you do not have any paths like that, then you might prefer to use a
-        # laxer rule, such as:
-        #   location ~ \.php(/|$) {
-        # The laxer rule will continue to work if Drupal uses this new URL
-        # pattern with front controllers other than update.php in a future
-        # release.
-        location ~ '\.php$|^/update.php' {
-            fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
-            include fastcgi_params;
-            # Block httpoxy attacks. See https://httpoxy.org/.
-            fastcgi_param HTTP_PROXY "";
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-            fastcgi_param PATH_INFO $fastcgi_path_info;
-            fastcgi_param QUERY_STRING $query_string;
-            fastcgi_intercept_errors on;
-            fastcgi_buffers 8 16k;
-            fastcgi_buffer_size 32k;
-            fastcgi_connect_timeout 300;
-            fastcgi_send_timeout 300;
-            fastcgi_read_timeout 300;
-            # PHP 7 socket location.
-            #fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+	# In Drupal 8, we must also match new paths where the '.php' appears in
+	# the middle, such as update.php/selection. The rule we use is strict,
+	# and only allows this pattern with the update.php front controller.
+	# This allows legacy path aliases in the form of
+	# blog/index.php/legacy-path to continue to route to Drupal nodes. If
+	# you do not have any paths like that, then you might prefer to use a
+	# laxer rule, such as:
+	#   location ~ \.php(/|$) {
+	# The laxer rule will continue to work if Drupal uses this new URL
+	# pattern with front controllers other than update.php in a future
+	# release.
+	location ~ '\.php$|^/update.php' {
+	    fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+	    include fastcgi_params;
+	    # Block httpoxy attacks. See https://httpoxy.org/.
+	    fastcgi_param HTTP_PROXY "";
+	    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+	    fastcgi_param PATH_INFO $fastcgi_path_info;
+	    fastcgi_param QUERY_STRING $query_string;
+	    fastcgi_intercept_errors on;
+	    fastcgi_buffers 8 16k;
+	    fastcgi_buffer_size 32k;
+	    fastcgi_connect_timeout 300;
+	    fastcgi_send_timeout 300;
+	    fastcgi_read_timeout 300;
+	    # PHP 7 socket location.
+	    #fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 	    # run php-fpm over tcp port 9000, potentially lower performance than unix socket
-            fastcgi_pass localhost:9000;
-        }
+	    fastcgi_pass localhost:9000;
+	}
 
-        # help with styles
-        location ~ ^/sites/.*/files/styles/ {
-            try_files $uri @rewrite;
-        }
+	# help with styles
+	location ~ ^/sites/.*/files/styles/ {
+	    try_files $uri @rewrite;
+	}
 
-        # Handle private files through Drupal. Private file's path can come
-        # with a language prefix.
-        location ~ ^(/[a-z\-]+)?/system/files/ {
-            try_files $uri /index.php?$query_string;
-        }
+	# Handle private files through Drupal. Private file's path can come
+	# with a language prefix.
+	location ~ ^(/[a-z\-]+)?/system/files/ {
+	    try_files $uri /index.php?$query_string;
+	}
 
-        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-            try_files $uri @rewrite;
-            expires max;
-            log_not_found off;
-        }
+	location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+	    try_files $uri @rewrite;
+	    expires max;
+	    log_not_found off;
+	}
 	# Includes virtual hosts configs.
 	#include /etc/nginx/conf.d/*.conf;
     }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -18,9 +18,9 @@ include /etc/nginx/modules/*.conf;
 pid        /tmp/nginx.pid;
 
 events {
-	# The maximum number of simultaneous connections that can be opened by
-	# a worker process.
-	worker_connections 1024;
+        # The maximum number of simultaneous connections that can be opened by
+        # a worker process.
+        worker_connections 1024;
 }
 
 http {
@@ -94,8 +94,8 @@ http {
 
     # Specifies the main log format.
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
-		    '$status $body_bytes_sent "$http_referer" '
-		    '"$http_user_agent" "$http_x_forwarded_for"';
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
 
     # Sets the path, format, and configuration for a buffered log write.
     access_log /var/log/nginx/access.log main;
@@ -111,128 +111,128 @@ http {
 
     # reject http requests that set both Content-Length and Transfer-Encoding header fields for the crlf injection vulnerability
     map "$http_content_length:$http_transfer_encoding" $crlf_vuln {
-	default "0";
-	":chunked" "1";
+        default "0";
+        ":chunked" "1";
     }
 
     server {
-	listen		80 default_server;
-	listen      [::]:80 default_server;
-	root		/var/www/html/web;
-	index		index.php index.html index.htm;
-	server_name	localhost;
-	client_max_body_size	32m;
+        listen          80 default_server;
+        listen      [::]:80 default_server;
+        root            /var/www/html/web;
+        index           index.php index.html index.htm;
+        server_name     localhost;
+        client_max_body_size    32m;
 
-	# use variable from above to reject and close without response the connection
-	if ($crlf_vuln) {
-	   return 444;
-	}
+        # use variable from above to reject and close without response the connection
+        if ($crlf_vuln) {
+           return 444;
+        }
 
 
-	location = /favicon.ico {
-		log_not_found off;
-		access_log off;
-	}
+        location = /favicon.ico {
+                log_not_found off;
+                access_log off;
+        }
 
-	location = /robots.txt {
-	    allow all;
-	    log_not_found off;
-	    access_log off;
-	}
+        location = /robots.txt {
+            allow all;
+            log_not_found off;
+            access_log off;
+        }
 
-	# Very rarely should these ever be accessed outside of your lan
-	location ~* \.(txt|log)$ {
-	    allow 192.168.0.0/16;
-	    deny all;
-	}
+        # Very rarely should these ever be accessed outside of your lan
+        location ~* \.(txt|log)$ {
+            allow 192.168.0.0/16;
+            deny all;
+        }
 
-	location ~ \..*/.*\.php$ {
-	    return 403;
-	}
+        location ~ \..*/.*\.php$ {
+            return 403;
+        }
 
-	location ~ ^/sites/.*/private/ {
-	    return 403;
-	}
+        location ~ ^/sites/.*/private/ {
+            return 403;
+        }
 
-	# Block access to scripts in site files directory
-	location ~ ^/sites/[^/]+/files/.*\.php$ {
-	    deny all;
-	}
+        # Block access to scripts in site files directory
+        location ~ ^/sites/[^/]+/files/.*\.php$ {
+            deny all;
+        }
 
-	# Allow "Well-Known URIs" as per RFC 5785
-	location ~* ^/.well-known/ {
-	    allow all;
-	}
+        # Allow "Well-Known URIs" as per RFC 5785
+        location ~* ^/.well-known/ {
+            allow all;
+        }
 
-	# Block access to "hidden" files and directories whose names begin with a
-	# period. This includes directories used by version control systems such
-	# as Subversion or Git to store control files.
-	location ~ (^|/)\. {
-	    return 403;
-	}
+        # Block access to "hidden" files and directories whose names begin with a
+        # period. This includes directories used by version control systems such
+        # as Subversion or Git to store control files.
+        location ~ (^|/)\. {
+            return 403;
+        }
 
-	location / {
-	    try_files $uri /index.php?$query_string;
-	}
+        location / {
+            try_files $uri /index.php?$query_string;
+        }
 
-	location @rewrite {
-	    rewrite ^/(.*)$ /index.php?q=$1;
-	}
+        location @rewrite {
+            rewrite ^/(.*)$ /index.php?q=$1;
+        }
 
-	# Don't allow direct access to PHP files in the vendor directory.
-	location ~ /vendor/.*\.php$ {
-	    deny all;
-	    return 404;
-	}
+        # Don't allow direct access to PHP files in the vendor directory.
+        location ~ /vendor/.*\.php$ {
+            deny all;
+            return 404;
+        }
 
-	# In Drupal 8, we must also match new paths where the '.php' appears in
-	# the middle, such as update.php/selection. The rule we use is strict,
-	# and only allows this pattern with the update.php front controller.
-	# This allows legacy path aliases in the form of
-	# blog/index.php/legacy-path to continue to route to Drupal nodes. If
-	# you do not have any paths like that, then you might prefer to use a
-	# laxer rule, such as:
-	#   location ~ \.php(/|$) {
-	# The laxer rule will continue to work if Drupal uses this new URL
-	# pattern with front controllers other than update.php in a future
-	# release.
-	location ~ '\.php$|^/update.php' {
-	    fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
-	    include fastcgi_params;
-	    # Block httpoxy attacks. See https://httpoxy.org/.
-	    fastcgi_param HTTP_PROXY "";
-	    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-	    fastcgi_param PATH_INFO $fastcgi_path_info;
-	    fastcgi_param QUERY_STRING $query_string;
-	    fastcgi_intercept_errors on;
-	    fastcgi_buffers 8 16k;
-	    fastcgi_buffer_size 32k;
-	    fastcgi_connect_timeout 300;
-	    fastcgi_send_timeout 300;
-	    fastcgi_read_timeout 300;
-	    # PHP 7 socket location.
-	    #fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
-	    # run php-fpm over tcp port 9000, potentially lower performance than unix socket
-	    fastcgi_pass localhost:9000;
-	}
+        # In Drupal 8, we must also match new paths where the '.php' appears in
+        # the middle, such as update.php/selection. The rule we use is strict,
+        # and only allows this pattern with the update.php front controller.
+        # This allows legacy path aliases in the form of
+        # blog/index.php/legacy-path to continue to route to Drupal nodes. If
+        # you do not have any paths like that, then you might prefer to use a
+        # laxer rule, such as:
+        #   location ~ \.php(/|$) {
+        # The laxer rule will continue to work if Drupal uses this new URL
+        # pattern with front controllers other than update.php in a future
+        # release.
+        location ~ '\.php$|^/update.php' {
+            fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
+            include fastcgi_params;
+            # Block httpoxy attacks. See https://httpoxy.org/.
+            fastcgi_param HTTP_PROXY "";
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param PATH_INFO $fastcgi_path_info;
+            fastcgi_param QUERY_STRING $query_string;
+            fastcgi_intercept_errors on;
+            fastcgi_buffers 8 16k;
+            fastcgi_buffer_size 32k;
+            fastcgi_connect_timeout 300;
+            fastcgi_send_timeout 300;
+            fastcgi_read_timeout 300;
+            # PHP 7 socket location.
+            #fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+            # run php-fpm over tcp port 9000, potentially lower performance than unix socket
+            fastcgi_pass localhost:9000;
+        }
 
-	# help with styles
-	location ~ ^/sites/.*/files/styles/ {
-	    try_files $uri @rewrite;
-	}
+        # help with styles
+        location ~ ^/sites/.*/files/styles/ {
+            try_files $uri @rewrite;
+        }
 
-	# Handle private files through Drupal. Private file's path can come
-	# with a language prefix.
-	location ~ ^(/[a-z\-]+)?/system/files/ {
-	    try_files $uri /index.php?$query_string;
-	}
+        # Handle private files through Drupal. Private file's path can come
+        # with a language prefix.
+        location ~ ^(/[a-z\-]+)?/system/files/ {
+            try_files $uri /index.php?$query_string;
+        }
 
-	location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-	    try_files $uri @rewrite;
-	    expires max;
-	    log_not_found off;
-	}
-	# Includes virtual hosts configs.
-	#include /etc/nginx/conf.d/*.conf;
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+            try_files $uri @rewrite;
+            expires max;
+            log_not_found off;
+        }
+        # Includes virtual hosts configs.
+        #include /etc/nginx/conf.d/*.conf;
     }
 }


### PR DESCRIPTION
Debian Buster is busted from a vulnerability scanning perspective. This PR switches the base Linux distribution to Alpine. 

**Changes**
1) Swap from debian buster to alpine 3.11. **Note: I couldn't use alpine 3.12 because ECR does not support scanning that distro yet** 
2) Version pinning. To make images as consistent as I can, I'm pinning the image versions for anything install with apk or curl. 
3) Updates to Composer. Composer was pinned to a version from 2018. This PR updates it to 1.10.10
4) Nginx goes back to 1.16. Unfortunately Nginx tied to alpine 3.11 is still on 1.16.x, and we were on 1.18.x previously. The version is still the latest patch and doesn't show any known vulnerabilities. The trade off here is simplicity in the dockerfile. I could go back and manually build a 1.18.x version of nginx, but that doesn't seem prudent here. 
5) Slight changes to the nginx config. Nginx on alpine has some slight differences about where tmp files live and I needed to make some update those paths to /tmp
6) Always deploy to stg on branches. Since there isn't a lot of contention and I get my feedback quickly, I'm allowing deploys to staging off of feature branches. 

**Benefits**
1) Requiring vulnerability scanning to pass before deploys. This is the best part, we not longer have to contend with 256 known vulnerabilities and scanning passes.  
2) Reduced image size. Switching from debian to alpine dropped the image size from 340MB down to 210MB which is around 30% improvement. 
