### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     time: "11:00"
   labels:
   - dependencies
+  open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/web/themes/custom/move_mil"
   schedule:
@@ -14,6 +15,7 @@ updates:
     time: "11:00"
   labels:
   - dependencies
+  open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/web/modules/custom/react_tools/tools"
   schedule:
@@ -21,6 +23,7 @@ updates:
     time: "11:00"
   labels:
   - dependencies
+  open-pull-requests-limit: 10
 - package-ecosystem: composer
   directory: "/"
   schedule:
@@ -28,3 +31,4 @@ updates:
     time: "11:00"
   labels:
   - dependencies
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Based on this [doc](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit) trying to see if we can bump the limit from the default 5.
