### PR TITLE
configure deploy and health check to be exclusive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,8 @@ commands:
             echo ${CONFIG} > Dockerrun.aws.json
             git add Dockerrun.aws.json
       - run:
-          name: EB Deploy
-          command: >
-            eb deploy << parameters.environment >> --staged
-      - run:
-          name: Health check app site
-          command: for retry in `seq 1 10`; do if curl -k -f -sS -o /dev/null << parameters.url >>; then echo Passed.; exit 0; else sleep $(($retry*3)); fi; done; exit 1
+          name: EB Deploy and health check app site
+          command: ./scripts/do-exclusively --job-name ${CIRCLE_JOB} ./scripts/deploy-and-health-check << parameters.environment >> << parameters.url >>
 
 # Reusable steps.
 ## Defines images and working directory.

--- a/scripts/deploy-and-health-check
+++ b/scripts/deploy-and-health-check
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+environment="${1}"
+url="${2}"
+
+# Deploy to Elastic Beanstalk.
+eb deploy "${environment}" --staged
+
+# Run a health check.
+for retry in $(seq 1 10); do
+    if curl -k -f -sS -o /dev/null "${url}"; then
+        echo Passed.
+        exit 0
+    else
+        sleep $((retry*3))
+    fi
+done
+exit 1

--- a/scripts/do-exclusively
+++ b/scripts/do-exclusively
@@ -1,0 +1,101 @@
+#! /usr/bin/env bash
+
+########################################################################################
+# CircleCI's current recommendation for roughly serializing a subset
+# of build commands for a given branch
+#
+# circle discussion thread - https://discuss.circleci.com/t/serializing-deployments/153
+# Code from - https://github.com/bellkev/circle-lock-test
+########################################################################################
+
+
+# sets $branch, $job_name, $tag, $rest
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -b|--branch) branch="$2" ;;
+            -j|--job-name) job_name="$2" ;;
+            -t|--tag) tag="$2" ;;
+            *) break ;;
+        esac
+        shift 2
+    done
+    rest=("$@")
+}
+
+# reads $branch, $tag, $commit_message
+should_skip() {
+    if [[ "$branch" && "$CIRCLE_BRANCH" != "$branch" ]]; then
+        echo "Not on branch $branch. Skipping..."
+        return 0
+    fi
+
+    if [[ "$job_name" && "$CIRCLE_JOB" != "$job_name" ]]; then
+        echo "Not running $job_name. Skipping..."
+        return 0
+    fi
+
+    if [[ "$tag" && "$commit_message" != *\[$tag\]* ]]; then
+        echo "No [$tag] commit tag found. Skipping..."
+        return 0
+    fi
+
+    return 1
+}
+
+# reads $branch, $job_name, $tag
+# sets $jq_prog
+make_jq_prog() {
+    local jq_filters=""
+
+    if [[ $branch ]]; then
+        jq_filters+=" and .branch == \"$branch\""
+    fi
+
+    if [[ $job_name ]]; then
+        jq_filters+=" and .workflows?.job_name? == \"$job_name\""
+    fi
+
+    if [[ $tag ]]; then
+        jq_filters+=" and (.subject | contains(\"[$tag]\"))"
+    fi
+
+    jq_prog=".[] | select(.build_num < $CIRCLE_BUILD_NUM and (.status | test(\"running|pending|queued\")) $jq_filters) | .build_num"
+}
+
+
+if [[ "$0" != *bats* ]]; then
+set -e
+set -u
+set -o pipefail
+
+    branch=""
+    tag=""
+    rest=()
+    api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
+
+    parse_args "$@"
+    commit_message=$(git log -1 --pretty=%B)
+    if should_skip; then exit 0; fi
+    make_jq_prog
+
+    echo "Checking for running builds..."
+
+    while true; do
+        builds=$(curl -s -H "Accept: application/json" "$api_url" | jq "$jq_prog")
+        if [[ $builds ]]; then
+            echo "Waiting on builds:"
+            echo "$builds"
+        else
+            break
+        fi
+        echo "Retrying in 10 seconds..."
+        sleep 10
+    done
+
+    echo "Acquired lock"
+
+    if [[ "${#rest[@]}" -ne 0 ]]; then
+        "${rest[@]}"
+    fi
+fi


### PR DESCRIPTION
Copy the do-exclusively script [from mymove](https://github.com/transcom/mymove/blob/1994180a79ffa3fc2614eef5dc861e4e83871982/scripts/do-exclusively). Configure it to wrap the deployment and health check, so that commits and pull requests don't cause each other to fail when they are being run at the same time in CircleCI.