### PR TITLE
add flags to the deploy-and-health-check script

### DIFF
--- a/scripts/deploy-and-health-check
+++ b/scripts/deploy-and-health-check
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eux -o pipefail
 
 environment="${1}"
 url="${2}"


### PR DESCRIPTION
We had a few successes that were not really successes.

https://app.circleci.com/pipelines/github/transcom/move.mil/665/workflows/a1969a16-11ca-4d04-bef0-89fd106e47aa/jobs/7077

```text
#!/bin/bash -eo pipefail
./scripts/do-exclusively --job-name ${CIRCLE_JOB} ./scripts/deploy-and-health-check movemil-stg https://movemil-stg.us-east-1.elasticbeanstalk.com/
Checking for running builds...
Waiting on builds:
7076
7072
7071
7070
Retrying in 10 seconds...
Waiting on builds:
7076
7072
7071
Retrying in 10 seconds...
Acquired lock
Alert: The platform version that your environment is using isn't recommended. There's a recommended version in the same platform branch.

Creating application version archive "app-1_0-1092-g8c18-210302_215220-stage-210302_215220".
Uploading Move.mil/app-1_0-1092-g8c18-210302_215220-stage-210302_215220.zip to S3. This may take a while.
Upload Complete.
ERROR: InvalidParameterValueError - Environment named movemil-stg is in an invalid state for this operation. Must be Ready.
Passed.
```

The flags added with this PR should hopefully address this.