### PR TITLE
double the timeout when deploying elastic beanstalk

### DIFF
--- a/scripts/deploy-and-health-check
+++ b/scripts/deploy-and-health-check
@@ -5,7 +5,7 @@ environment="${1}"
 url="${2}"
 
 # Deploy to Elastic Beanstalk.
-eb deploy "${environment}" --staged
+eb deploy "${environment}" --staged --timeout 20
 
 # Run a health check.
 for retry in $(seq 1 10); do


### PR DESCRIPTION
Periodically, we see timeouts during what appears to be a successful deploy. Normally deploys take just under 10 minutes (the default timeout). However, sometimes they take a little longer and result in an error:

```text
Creating application version archive "app-1_0-1175-g6830-210308_174631-stage-210308_174631".
Uploading Move.mil/app-1_0-1175-g6830-210308_174631-stage-210308_174631.zip to S3. This may take a while.
Upload Complete.
2021-03-08 17:46:32    INFO    Environment update is starting.      
2021-03-08 17:47:16    INFO    Deploying new version to instance(s).
2021-03-08 17:47:17    INFO    Batch 1: Starting application deployment on instance(s) [i-0b710110f3c991629].
2021-03-08 17:47:40    INFO    Batch 1: Starting application deployment command execution.
2021-03-08 17:48:40    INFO    Successfully pulled ********************************************/************:6830cfd7c8a11867bbd7c27d28524edccc60fba4
2021-03-08 17:49:14    INFO    Successfully built aws_beanstalk/staging-app
2021-03-08 17:49:26    INFO    Docker container 4fdcc2ed7ce6 is running aws_beanstalk/current-app.
2021-03-08 17:49:28    INFO    Batch 1: Completed application deployment command execution.
2021-03-08 17:49:28    INFO    Command execution completed on 1 of 2 instances in environment.
2021-03-08 17:49:29    INFO    Batch 1: Registering instance(s) with the load balancer and waiting for them to be healthy. 
2021-03-08 17:51:43    INFO    Batch 1: Completed application deployment.
2021-03-08 17:51:44    INFO    Batch 2: Starting application deployment on instance(s) [i-04e83b34b5dc3271c].
2021-03-08 17:52:06    INFO    Batch 2: Starting application deployment command execution.
2021-03-08 17:53:03    INFO    Successfully pulled ********************************************/************:6830cfd7c8a11867bbd7c27d28524edccc60fba4
2021-03-08 17:53:40    INFO    Successfully built aws_beanstalk/staging-app
2021-03-08 17:53:51    INFO    Docker container 343b5f0507ee is running aws_beanstalk/current-app.
2021-03-08 17:53:55    INFO    Batch 2: Completed application deployment command execution.
2021-03-08 17:53:55    INFO    Command execution completed on 2 of 2 instances in environment.
2021-03-08 17:53:55    INFO    Batch 2: Registering instance(s) with the load balancer and waiting for them to be healthy. 
2021-03-08 17:56:10    INFO    Batch 2: Completed application deployment.
                                                                      
ERROR: TimeoutError - The EB CLI timed out after 10 minute(s). The operation might still be running. To keep viewing events, run 'eb events -f'. To set timeout duration, use '--timeout MINUTES'.
```

This PR aims to increase the timeout to account for those edge cases.