### PR TITLE
MB-7216: update webpack-manifest-plugin to 3.1.0

### DIFF
--- a/web/modules/custom/react_tools/tools/config/webpack.config.js
+++ b/web/modules/custom/react_tools/tools/config/webpack.config.js
@@ -14,7 +14,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const safePostCssParser = require('postcss-safe-parser');
-const ManifestPlugin = require('webpack-manifest-plugin');
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WorkboxWebpackPlugin = require('workbox-webpack-plugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
@@ -541,7 +541,7 @@ function getConfig(webpackEnv, appName) {
               // Generate a manifest file which contains a mapping of all asset filenames
               // to their corresponding output file so that tools can pick it up without
               // having to parse `index.html`.
-              new ManifestPlugin({
+              new WebpackManifestPlugin({
                 fileName: 'asset-manifest.json',
                 publicPath: publicPath,
                 generate: (seed, files) => {

--- a/web/modules/custom/react_tools/tools/package-lock.json
+++ b/web/modules/custom/react_tools/tools/package-lock.json
@@ -24,7 +24,7 @@
         "babel-preset-react-app": "^10.0.0",
         "camelcase": "^6.2.0",
         "case-sensitive-paths-webpack-plugin": "2.4.0",
-        "css-loader": "^5.1.3",
+        "css-loader": "5.1.3",
         "dotenv": "8.2.0",
         "dotenv-expand": "5.1.0",
         "eslint": "^7.22.0",
@@ -75,7 +75,7 @@
         "url-loader": "4.1.1",
         "webpack": "4.46.0",
         "webpack-dev-server": "^3.11.2",
-        "webpack-manifest-plugin": "2.0.4",
+        "webpack-manifest-plugin": "^2.1.0",
         "workbox-webpack-plugin": "6.1.2"
       },
       "devDependencies": {
@@ -30320,9 +30320,9 @@
       }
     },
     "node_modules/webpack-manifest-plugin": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
-      "integrity": "sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.1.0.tgz",
+      "integrity": "sha512-vQn/mY9okBQUim6fQo+8lYzn/MWcSMGbGpQyKIR6c6NF++lVxfzdlZBL0FGVQsb1RFL/rPdKwu6hkbtWv6CEYg==",
       "dependencies": {
         "fs-extra": "^7.0.0",
         "lodash": ">=3.5 <5",
@@ -30330,6 +30330,9 @@
       },
       "engines": {
         "node": ">=6.11.5"
+      },
+      "peerDependencies": {
+        "webpack": "2 || 3 || 4"
       }
     },
     "node_modules/webpack-manifest-plugin/node_modules/fs-extra": {
@@ -56682,9 +56685,9 @@
       }
     },
     "webpack-manifest-plugin": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz",
-      "integrity": "sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.1.0.tgz",
+      "integrity": "sha512-vQn/mY9okBQUim6fQo+8lYzn/MWcSMGbGpQyKIR6c6NF++lVxfzdlZBL0FGVQsb1RFL/rPdKwu6hkbtWv6CEYg==",
       "requires": {
         "fs-extra": "^7.0.0",
         "lodash": ">=3.5 <5",

--- a/web/modules/custom/react_tools/tools/package-lock.json
+++ b/web/modules/custom/react_tools/tools/package-lock.json
@@ -75,7 +75,7 @@
         "url-loader": "4.1.1",
         "webpack": "4.46.0",
         "webpack-dev-server": "^3.11.2",
-        "webpack-manifest-plugin": "^2.2.0",
+        "webpack-manifest-plugin": "^3.0.0",
         "workbox-webpack-plugin": "6.1.2"
       },
       "devDependencies": {
@@ -30320,33 +30320,46 @@
       }
     },
     "node_modules/webpack-manifest-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz",
-      "integrity": "sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-3.0.0.tgz",
+      "integrity": "sha512-nbORTdky2HxD8XSaaT+zrsHb30AAgyWAWgCLWaAeQO21VGCScGb52ipqlHA/njix1Z8OW8IOlo4+XK0OKr1fkw==",
       "dependencies": {
-        "fs-extra": "^7.0.0",
-        "lodash": ">=3.5 <5",
-        "object.entries": "^1.1.0",
-        "tapable": "^1.0.0"
+        "tapable": "^2.0.0",
+        "webpack-sources": "^2.2.0"
       },
       "engines": {
-        "node": ">=6.11.5"
+        "node": ">=10.22.1"
       },
       "peerDependencies": {
-        "webpack": "2 || 3 || 4"
+        "webpack": ">=4.44.2"
       }
     },
-    "node_modules/webpack-manifest-plugin/node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+    "node_modules/webpack-manifest-plugin/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/webpack-manifest-plugin/node_modules/tapable": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+      "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/webpack-manifest-plugin/node_modules/webpack-sources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
+      "integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "source-list-map": "^2.0.1",
+        "source-map": "^0.6.1"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/webpack-sources": {
@@ -56686,24 +56699,31 @@
       }
     },
     "webpack-manifest-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz",
-      "integrity": "sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-3.0.0.tgz",
+      "integrity": "sha512-nbORTdky2HxD8XSaaT+zrsHb30AAgyWAWgCLWaAeQO21VGCScGb52ipqlHA/njix1Z8OW8IOlo4+XK0OKr1fkw==",
       "requires": {
-        "fs-extra": "^7.0.0",
-        "lodash": ">=3.5 <5",
-        "object.entries": "^1.1.0",
-        "tapable": "^1.0.0"
+        "tapable": "^2.0.0",
+        "webpack-sources": "^2.2.0"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "tapable": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.0.tgz",
+          "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw=="
+        },
+        "webpack-sources": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.2.0.tgz",
+          "integrity": "sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==",
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "source-list-map": "^2.0.1",
+            "source-map": "^0.6.1"
           }
         }
       }

--- a/web/modules/custom/react_tools/tools/package-lock.json
+++ b/web/modules/custom/react_tools/tools/package-lock.json
@@ -75,7 +75,7 @@
         "url-loader": "4.1.1",
         "webpack": "4.46.0",
         "webpack-dev-server": "^3.11.2",
-        "webpack-manifest-plugin": "^2.1.0",
+        "webpack-manifest-plugin": "^2.2.0",
         "workbox-webpack-plugin": "6.1.2"
       },
       "devDependencies": {
@@ -30320,12 +30320,13 @@
       }
     },
     "node_modules/webpack-manifest-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.1.0.tgz",
-      "integrity": "sha512-vQn/mY9okBQUim6fQo+8lYzn/MWcSMGbGpQyKIR6c6NF++lVxfzdlZBL0FGVQsb1RFL/rPdKwu6hkbtWv6CEYg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz",
+      "integrity": "sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==",
       "dependencies": {
         "fs-extra": "^7.0.0",
         "lodash": ">=3.5 <5",
+        "object.entries": "^1.1.0",
         "tapable": "^1.0.0"
       },
       "engines": {
@@ -56685,12 +56686,13 @@
       }
     },
     "webpack-manifest-plugin": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.1.0.tgz",
-      "integrity": "sha512-vQn/mY9okBQUim6fQo+8lYzn/MWcSMGbGpQyKIR6c6NF++lVxfzdlZBL0FGVQsb1RFL/rPdKwu6hkbtWv6CEYg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz",
+      "integrity": "sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==",
       "requires": {
         "fs-extra": "^7.0.0",
         "lodash": ">=3.5 <5",
+        "object.entries": "^1.1.0",
         "tapable": "^1.0.0"
       },
       "dependencies": {

--- a/web/modules/custom/react_tools/tools/package-lock.json
+++ b/web/modules/custom/react_tools/tools/package-lock.json
@@ -75,7 +75,7 @@
         "url-loader": "4.1.1",
         "webpack": "4.46.0",
         "webpack-dev-server": "^3.11.2",
-        "webpack-manifest-plugin": "^3.0.0",
+        "webpack-manifest-plugin": "^3.1.0",
         "workbox-webpack-plugin": "6.1.2"
       },
       "devDependencies": {
@@ -30320,9 +30320,9 @@
       }
     },
     "node_modules/webpack-manifest-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-3.0.0.tgz",
-      "integrity": "sha512-nbORTdky2HxD8XSaaT+zrsHb30AAgyWAWgCLWaAeQO21VGCScGb52ipqlHA/njix1Z8OW8IOlo4+XK0OKr1fkw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-3.1.0.tgz",
+      "integrity": "sha512-7jgB8Kb0MRWXq3YaDfe+0smv5c7MLMfze8YvG6eBEXZmy6fhwMe/eT47A0KEIF30c0DDEYKbbYTXzaMQETaZ0Q==",
       "dependencies": {
         "tapable": "^2.0.0",
         "webpack-sources": "^2.2.0"
@@ -56699,9 +56699,9 @@
       }
     },
     "webpack-manifest-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-3.0.0.tgz",
-      "integrity": "sha512-nbORTdky2HxD8XSaaT+zrsHb30AAgyWAWgCLWaAeQO21VGCScGb52ipqlHA/njix1Z8OW8IOlo4+XK0OKr1fkw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-3.1.0.tgz",
+      "integrity": "sha512-7jgB8Kb0MRWXq3YaDfe+0smv5c7MLMfze8YvG6eBEXZmy6fhwMe/eT47A0KEIF30c0DDEYKbbYTXzaMQETaZ0Q==",
       "requires": {
         "tapable": "^2.0.0",
         "webpack-sources": "^2.2.0"

--- a/web/modules/custom/react_tools/tools/package.json
+++ b/web/modules/custom/react_tools/tools/package.json
@@ -70,7 +70,7 @@
     "url-loader": "4.1.1",
     "webpack": "4.46.0",
     "webpack-dev-server": "^3.11.2",
-    "webpack-manifest-plugin": "^2.1.0",
+    "webpack-manifest-plugin": "^2.2.0",
     "workbox-webpack-plugin": "6.1.2"
   },
   "scripts": {

--- a/web/modules/custom/react_tools/tools/package.json
+++ b/web/modules/custom/react_tools/tools/package.json
@@ -70,7 +70,7 @@
     "url-loader": "4.1.1",
     "webpack": "4.46.0",
     "webpack-dev-server": "^3.11.2",
-    "webpack-manifest-plugin": "^3.0.0",
+    "webpack-manifest-plugin": "^3.1.0",
     "workbox-webpack-plugin": "6.1.2"
   },
   "scripts": {

--- a/web/modules/custom/react_tools/tools/package.json
+++ b/web/modules/custom/react_tools/tools/package.json
@@ -70,7 +70,7 @@
     "url-loader": "4.1.1",
     "webpack": "4.46.0",
     "webpack-dev-server": "^3.11.2",
-    "webpack-manifest-plugin": "2.0.4",
+    "webpack-manifest-plugin": "^2.1.0",
     "workbox-webpack-plugin": "6.1.2"
   },
   "scripts": {

--- a/web/modules/custom/react_tools/tools/package.json
+++ b/web/modules/custom/react_tools/tools/package.json
@@ -70,7 +70,7 @@
     "url-loader": "4.1.1",
     "webpack": "4.46.0",
     "webpack-dev-server": "^3.11.2",
-    "webpack-manifest-plugin": "^3.1.0",
+    "webpack-manifest-plugin": "3.1.0",
     "workbox-webpack-plugin": "6.1.2"
   },
   "scripts": {

--- a/web/modules/custom/react_tools/tools/package.json
+++ b/web/modules/custom/react_tools/tools/package.json
@@ -70,7 +70,7 @@
     "url-loader": "4.1.1",
     "webpack": "4.46.0",
     "webpack-dev-server": "^3.11.2",
-    "webpack-manifest-plugin": "^2.2.0",
+    "webpack-manifest-plugin": "^3.0.0",
     "workbox-webpack-plugin": "6.1.2"
   },
   "scripts": {


### PR DESCRIPTION
I have a suspicion that this may be causing problems with my attempts to upgrade webpack, so this PR should hopefully either address those issues if they exist or rule them out as possible conflicts. Specifically, the [release notes for v3.0.0 of webpack-manifest-plugin](https://github.com/shellscape/webpack-manifest-plugin/releases/tag/v3.0.0) indicate added compatibility with webpack v5. My suspicion is that upgrading webpack-manifest-plugin will enable the webpack v5 upgrade to be possible.