### PR TITLE
disable ecr scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@
 
 orbs:
   aws-ecr: circleci/aws-ecr@6.12.2
-  ecr-image-scan-findings: trussworks/orb-ecr-image-scan-findings@1.1.1
 
 commands:
   deploy_app_steps:
@@ -231,18 +230,12 @@ workflows:
 
       - build-image
 
-      - ecr-image-scan-findings/scan:
-          requires:
-            - build-image
-          ecr-repository-name: ${ECR_REPO}
-
       - deploy-app-stg:
           requires:
             - behat
             - code-sniffer
             - code-coverage
             - build-image
-            - ecr-image-scan-findings/scan
           #filters:
           #  branches:
           #    only: master


### PR DESCRIPTION
ECR has been [failing](https://app.circleci.com/pipelines/github/transcom/move.mil/1096/workflows/1e7d05e7-cbef-44c7-b4fb-396be5ad9536/jobs/9366) for [weeks](https://app.circleci.com/pipelines/github/transcom/move.mil/1096/workflows/e763e471-d11f-4fa6-85b0-bb9c0048b2a5/jobs/9433) due to a false positive report of musl: https://github.com/quay/clair/issues/1200

<details><summary>False positive output</summary>

```
{
  "imageScanFindings": {
    "findings": [
      {
        "name": "CVE-2020-28928",
        "uri": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28928",
        "severity": "LOW",
        "attributes": [
          {
            "key": "package_version",
            "value": "1.2.2-r0"
          },
          {
            "key": "package_name",
            "value": "musl"
          },
          {
            "key": "CVSS2_VECTOR",
            "value": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
          },
          {
            "key": "CVSS2_SCORE",
            "value": "2.1"
          }
        ]
      }
    ],
    "imageScanCompletedAt": "2021-04-08T18:39:32+00:00",
    "vulnerabilitySourceUpdatedAt": "2021-04-08T07:58:00+00:00",
    "findingSeverityCounts": {
      "LOW": 1
    }
  },
  "registryId": "************",
  "repositoryName": "************",
  "imageId": {
    "imageDigest": "sha256:5baf42e9bb469011dfed8c1bfeccd401f35f8e42958228c7b3934a067770df95",
    "imageTag": "eca13825c64efe1168cd1df427cde8ac43c7bf4e"
  },
  "imageScanStatus": {
    "status": "COMPLETE",
    "description": "The scan was completed successfully."
  }
}
```
</details>

ECR scanning consistently reports false positives. See: https://forums.aws.amazon.com/thread.jspa?threadID=337518

To keep our application up to date, I'm removing this ECR scan step so that we don't block the resolution of multiple other vulnerabilities that need to be fixed.