### PR TITLE
MB-8947: increase max execution time for php

### DIFF
--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,3 +1,4 @@
+max_execution_time = 120
+memory_limit = 1536M
 post_max_size = 24M
 upload_max_filesize = 20M
-memory_limit = 1536M


### PR DESCRIPTION
We repeatedly get this error when trying to reset passwords:

```
Fatal error: Maximum execution time of 30 seconds exceeded in /var/www/html/web/core/lib/Drupal/Core/Password/PhpassHashedPassword.php on line 187
```

This PR tries to address this by increasing the max execution time from the default of 30 seconds to 120 seconds.