### PR TITLE
exclude e availability zone

### DIFF
--- a/.ebextensions/efs-create.config
+++ b/.ebextensions/efs-create.config
@@ -1,6 +1,4 @@
 option_settings:
-  aws:autoscaling:launchconfiguration:
-    InstanceType: t4g.small
   aws:elasticbeanstalk:customoption:
     EFSVolumeName: "movemil-drupalfiles"
     VPCId: "vpc-05efa8ec035aaeade"
@@ -9,7 +7,8 @@ option_settings:
     SubnetB: "subnet-0acf5bb4fd52b7198"
     SubnetC: "subnet-045ac8dce039b2959"
     SubnetD: "subnet-02ec6772856fd6ef5"
-    SubnetE: "subnet-014f69867879b5bb2"
+    # Remove subnetE from the pool, since t3.small instances are not available there.
+    # SubnetE: "subnet-014f69867879b5bb2"
     SubnetF: "subnet-06017b0cb1742c394"
 Resources:
 ## Mount Target Resources

--- a/.ebextensions/efs-create.config
+++ b/.ebextensions/efs-create.config
@@ -1,4 +1,6 @@
 option_settings:
+  aws:autoscaling:launchconfiguration:
+    InstanceType: t4g.small
   aws:elasticbeanstalk:customoption:
     EFSVolumeName: "movemil-drupalfiles"
     VPCId: "vpc-05efa8ec035aaeade"
@@ -7,8 +9,7 @@ option_settings:
     SubnetB: "subnet-0acf5bb4fd52b7198"
     SubnetC: "subnet-045ac8dce039b2959"
     SubnetD: "subnet-02ec6772856fd6ef5"
-    # Remove subnetE from the pool, since t3.small instances are not available there.
-    # SubnetE: "subnet-014f69867879b5bb2"
+    SubnetE: "subnet-014f69867879b5bb2"
     SubnetF: "subnet-06017b0cb1742c394"
 Resources:
 ## Mount Target Resources
@@ -44,14 +45,14 @@ Resources:
       - {Ref: MountTargetSecurityGroup}
       SubnetId:
         Fn::GetOptionSetting: {OptionName: SubnetD}
-  # MountTargetE:
-  #   Type: AWS::EFS::MountTarget
-  #   Properties:
-  #     FileSystemId: {Ref: FileSystem}
-  #     SecurityGroups:
-  #     - {Ref: MountTargetSecurityGroup}
-  #     SubnetId:
-  #       Fn::GetOptionSetting: {OptionName: SubnetE}
+  MountTargetE:
+    Type: AWS::EFS::MountTarget
+    Properties:
+      FileSystemId: {Ref: FileSystem}
+      SecurityGroups:
+      - {Ref: MountTargetSecurityGroup}
+      SubnetId:
+        Fn::GetOptionSetting: {OptionName: SubnetE}
   MountTargetF:
     Type: AWS::EFS::MountTarget
     Properties:

--- a/.ebextensions/efs-create.config
+++ b/.ebextensions/efs-create.config
@@ -44,14 +44,14 @@ Resources:
       - {Ref: MountTargetSecurityGroup}
       SubnetId:
         Fn::GetOptionSetting: {OptionName: SubnetD}
-  MountTargetE:
+  <!-- MountTargetE:
     Type: AWS::EFS::MountTarget
     Properties:
       FileSystemId: {Ref: FileSystem}
       SecurityGroups:
       - {Ref: MountTargetSecurityGroup}
       SubnetId:
-        Fn::GetOptionSetting: {OptionName: SubnetE}
+        Fn::GetOptionSetting: {OptionName: SubnetE} -->
   MountTargetF:
     Type: AWS::EFS::MountTarget
     Properties:

--- a/.ebextensions/efs-create.config
+++ b/.ebextensions/efs-create.config
@@ -1,4 +1,6 @@
 option_settings:
+  aws:autoscaling:launchconfiguration:
+    InstanceType: t4g.small
   aws:elasticbeanstalk:customoption:
     EFSVolumeName: "movemil-drupalfiles"
     VPCId: "vpc-05efa8ec035aaeade"

--- a/.ebextensions/efs-create.config
+++ b/.ebextensions/efs-create.config
@@ -44,14 +44,14 @@ Resources:
       - {Ref: MountTargetSecurityGroup}
       SubnetId:
         Fn::GetOptionSetting: {OptionName: SubnetD}
-  <!-- MountTargetE:
-    Type: AWS::EFS::MountTarget
-    Properties:
-      FileSystemId: {Ref: FileSystem}
-      SecurityGroups:
-      - {Ref: MountTargetSecurityGroup}
-      SubnetId:
-        Fn::GetOptionSetting: {OptionName: SubnetE} -->
+  # MountTargetE:
+  #   Type: AWS::EFS::MountTarget
+  #   Properties:
+  #     FileSystemId: {Ref: FileSystem}
+  #     SecurityGroups:
+  #     - {Ref: MountTargetSecurityGroup}
+  #     SubnetId:
+  #       Fn::GetOptionSetting: {OptionName: SubnetE}
   MountTargetF:
     Type: AWS::EFS::MountTarget
     Properties:


### PR DESCRIPTION
We are getting this error during the deployment:
```
2021-09-08 19:41:04    ERROR   "option_settings" in one of the configuration files failed validation. More details to follow.                                            
2021-09-08 19:41:04    ERROR   Invalid option specification (Namespace: 'aws:ec2:instances', OptionName: 'InstanceTypes'): Your selected instance types (t3.small) aren't available in your selected VPC Subnets. t3.small is available in [us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f]. Please check your VPC Subnets.            
2021-09-08 19:41:04    ERROR   Invalid option specification (Namespace: 'aws:autoscaling:launchconfiguration', OptionName: 'InstanceType'): Your selected instance types (t3.small) aren't available in your selected VPC Subnets. t3.small is available in [us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f]. Please check your VPC Sub
nets.                                                                               
2021-09-08 19:41:04    ERROR   Failed to deploy application.     
```

So we're trying this change to see if it works.